### PR TITLE
폰트 테두리 추가, 최후변론 view 추가

### DIFF
--- a/Balance-Catch-iOS/Balance-Catch-iOS.xcodeproj/project.pbxproj
+++ b/Balance-Catch-iOS/Balance-Catch-iOS.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		3950658129CC949600A9C925 /* SelectBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3950658029CC949600A9C925 /* SelectBox.swift */; };
 		3950658329CC94AF00A9C925 /* SelectButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3950658229CC94AF00A9C925 /* SelectButton.swift */; };
 		3950658529CC961300A9C925 /* TimerCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3950658429CC961300A9C925 /* TimerCode.swift */; };
+		39A1561829DC0F7F000968CA /* FinalSpeakingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A1561729DC0F7F000968CA /* FinalSpeakingView.swift */; };
+		39A1561A29DC1899000968CA /* VSstyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A1561929DC1899000968CA /* VSstyle.swift */; };
 		53A7B0AD29C333D300B99211 /* PlayerNameInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A7B0AC29C333D300B99211 /* PlayerNameInputView.swift */; };
 		53A7B0AF29C334B000B99211 /* SelectQuestionThemeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A7B0AE29C334B000B99211 /* SelectQuestionThemeView.swift */; };
 		5624C4AE29BFF7CE008C7898 /* Balance_Catch_iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5624C4AD29BFF7CE008C7898 /* Balance_Catch_iOSApp.swift */; };
@@ -76,6 +78,8 @@
 		3950658029CC949600A9C925 /* SelectBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectBox.swift; sourceTree = "<group>"; };
 		3950658229CC94AF00A9C925 /* SelectButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectButton.swift; sourceTree = "<group>"; };
 		3950658429CC961300A9C925 /* TimerCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerCode.swift; sourceTree = "<group>"; };
+		39A1561729DC0F7F000968CA /* FinalSpeakingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinalSpeakingView.swift; sourceTree = "<group>"; };
+		39A1561929DC1899000968CA /* VSstyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VSstyle.swift; sourceTree = "<group>"; };
 		53A7B0AC29C333D300B99211 /* PlayerNameInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerNameInputView.swift; sourceTree = "<group>"; };
 		53A7B0AE29C334B000B99211 /* SelectQuestionThemeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectQuestionThemeView.swift; sourceTree = "<group>"; };
 		5624C4AA29BFF7CE008C7898 /* Balance-Catch-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Balance-Catch-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -224,6 +228,7 @@
 				33E60C9C29CC2FC3005EC0AF /* PercentageBar.swift */,
 				33E60CA029CC736C005EC0AF /* BiggerRoundBlueButton.swift */,
 				33E60CA229CC88DE005EC0AF /* NameBoxButton.swift */,
+				39A1561929DC1899000968CA /* VSstyle.swift */,
 			);
 			path = Custom;
 			sourceTree = "<group>";
@@ -255,6 +260,7 @@
 				33A83C7E29CA375700C0FA16 /* RecommandOrNotView.swift */,
 				33E60C9629CC1B28005EC0AF /* PublicPickView.swift */,
 				33E60C9E29CC6F3B005EC0AF /* WhoIsLoserView.swift */,
+				39A1561729DC0F7F000968CA /* FinalSpeakingView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -391,6 +397,7 @@
 			files = (
 				56930FD329D59861006CEA3F /* QuestionPickerView.swift in Sources */,
 				3950657D29CC943B00A9C925 /* TimerView.swift in Sources */,
+				39A1561A29DC1899000968CA /* VSstyle.swift in Sources */,
 				3950657929CC93AF00A9C925 /* SelectTypeView.swift in Sources */,
 				56E2E49F29C03B050023095C /* CGFloat+.swift in Sources */,
 				563FBD5C29C96F3500847390 /* Question.swift in Sources */,
@@ -401,6 +408,7 @@
 				33E60CA129CC736C005EC0AF /* BiggerRoundBlueButton.swift in Sources */,
 				33E60C9D29CC2FC4005EC0AF /* PercentageBar.swift in Sources */,
 				56E2E4A629C03E040023095C /* Font+.swift in Sources */,
+				39A1561829DC0F7F000968CA /* FinalSpeakingView.swift in Sources */,
 				33A83C7F29CA375700C0FA16 /* RecommandOrNotView.swift in Sources */,
 				56E2E4A129C03BB30023095C /* ShapeStyle+.swift in Sources */,
 				3950657F29CC945E00A9C925 /* UserFinalSelectView.swift in Sources */,

--- a/Balance-Catch-iOS/Balance-Catch-iOS/Custom/VSstyle.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/Custom/VSstyle.swift
@@ -1,0 +1,27 @@
+//
+//  VSstyle.swift
+//  Balance-Catch-iOS
+//
+//  Created by 민지은 on 2023/04/04.
+//
+
+import SwiftUI
+
+struct StrokeText: View {
+    let text: String
+    let width: CGFloat
+    let color: Color
+
+    var body: some View {
+        ZStack{
+            ZStack{
+                Text(text).offset(x:  width, y:  width)
+                Text(text).offset(x: -width, y: -width)
+                Text(text).offset(x: -width, y:  width)
+                Text(text).offset(x:  width, y: -width)
+            }
+            .foregroundColor(color)
+            Text(text)
+        }
+    }
+}

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/FinalSpeakingView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/FinalSpeakingView.swift
@@ -1,0 +1,62 @@
+//
+//  FinalSpeakingView.swift
+//  Balance-Catch-iOS
+//
+//  Created by 민지은 on 2023/04/04.
+//
+
+import SwiftUI
+
+struct FinalSpeakingView: View {
+    
+    var body: some View{
+        
+            Spacer()
+        
+            VStack{
+                Text("최후 변론 TIME")
+                    .font(.system(size:36))
+                    .fontWeight(.bold)
+                    .shadow(color:.gray,radius:2,x:3,y:3)
+                    .padding(.bottom, 35)
+                    .padding(.top,-10)
+                
+                HStack{
+                    Text("Player 1")
+                        .font(.system(size:24))
+                        .fontWeight(.bold)
+                        .shadow(color:.gray,radius:2,x:3,y:3)
+                    
+                    Text("제리")
+                        .font(.system(size:20))
+                        .fontWeight(.bold)
+                        .frame(width: 150, height: 56)
+                        .background(Color.white)
+                        .cornerRadius(20)
+                        .shadow(color:.gray,radius:2,x:3,y:3)
+                        .overlay(RoundedRectangle(cornerRadius: 20)
+                            .stroke(Color("BalanceCatchBlue").opacity(1),lineWidth: 4))
+                        .padding(.leading, 24)
+                    
+                }.padding(.bottom, 40)
+                
+                TimerCode()
+                
+                NavigationLink("Next") {
+                    UserFinalSelectView()
+                }
+                .buttonStyle(RoundedBlueButton())
+            }//Vstack
+        
+            Spacer()
+        
+    }
+    
+}
+
+
+struct FinalSpeakingView_Previews: PreviewProvider {
+    static var previews: some View {
+        FinalSpeakingView()
+    }
+}

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/TimerView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/TimerView.swift
@@ -21,7 +21,7 @@ struct TimerView: View {
                 TimerCode()
                 
                 NavigationLink("Next") {
-                    UserFinalSelectView()
+                    FinalSpeakingView()
                 }
                 .buttonStyle(RoundedBlueButton())
             }//Vstack
@@ -31,7 +31,7 @@ struct TimerView: View {
 }
 
 
-struct TiimerView_Previews: PreviewProvider {
+struct TimerView_Previews: PreviewProvider {
     static var previews: some View {
         TimerView()
     }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFinalSelectView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFinalSelectView.swift
@@ -63,6 +63,7 @@ struct UserFinalSelectView: View {
                     .buttonStyle(SelectButton(isActivated: $isActivated1))
                     .zIndex(0)
                     .offset(x:-90)
+                    .padding(.bottom, 23)
                     
                     
                     
@@ -87,11 +88,11 @@ struct UserFinalSelectView: View {
                     
                 }
                 
-                Text("VS")
-                    .font(.system(size:64))
-                    .fontWeight(.black)
-                    .shadow(color:.gray,radius:2, x: 3, y:3)
-                    .zIndex(1)
+                StrokeText(text: "VS",width: 2, color: Color("BalanceCatchBlue"))
+                    .foregroundColor(.black)
+                    .font(.system(size: 64, weight: .black))
+                    .shadow(color:.gray,radius:2, x: 1, y:1)
+                    .padding(.bottom, 25)
             }
             
             NavigationLink("Next") {

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFirstSelectView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFirstSelectView.swift
@@ -10,7 +10,6 @@ import Foundation
 
 struct UserFirstSelectView: View {
     let selectedQuestion: Question
-    //var questions: [Question] = getNewQuestionList()
     @State private var isActivated1: Bool = false
     @State private var isActivated2: Bool = false
     @State var showingSubview = false
@@ -85,6 +84,7 @@ struct UserFirstSelectView: View {
                     .buttonStyle(SelectButton(isActivated: $isActivated1))
                     .zIndex(0)
                     .offset(x:-90)
+                    .padding(.bottom, 23)
                     
                     
                     
@@ -107,13 +107,16 @@ struct UserFirstSelectView: View {
                     .offset(x: 90)
                     .offset(x: showingSubview ? 0 : 150, y: 0)
                     
+                    
                 }
                 
-                Text("VS")
-                    .font(.system(size:64))
-                    .fontWeight(.black)
-                    .shadow(color:.gray,radius:2, x: 3, y:3)
-                    .zIndex(1)
+                StrokeText(text: "VS",width: 2, color: Color("BalanceCatchBlue"))
+                    .foregroundColor(.black)
+                    .font(.system(size: 64, weight: .black))
+                    .shadow(color:.gray,radius:2, x: 1, y:1)
+                    .padding(.bottom, 25)
+                
+                
             }
             
             NavigationLink("Next") {
@@ -132,18 +135,6 @@ struct UserFirstSelectView: View {
     }
     
 }
-
-//func getNewQuestionList() -> [Question] {
-//    let qustionTexts = QuestionTexts().list
-//    var newQuestionList: [Question] = []
-//
-//    qustionTexts.forEach { questionText in
-//        let newQuestion = Question(text: questionText)
-//        newQuestionList.append(newQuestion)
-//    }
-//    return newQuestionList
-//}
-
 
 struct UserFirstSelect_Previews: PreviewProvider {
     static var previews: some View {


### PR DESCRIPTION
## Motivation ⍰

- UserFirstSelectView와 UserFinalSelectView가 Figma에서 디자인한 화면과 차이가 있었음
- 최후변론 View가 없었음

<br>

## Key Changes 🔑

- UserFirstSelectView와 UserFinalSelectView 선택지 간격 변경
- UserFirstSelectView와 UserFinalSelectView의 "VS" 테두리 추가
- 최후변론 시간을 나타내는 FinalSpeakingView() 추가
- "VS"를 커스텀 해놓은 VSstyle 파일 추가

<br>

## To Reviewers 🙏🏻

- @eundeang VSstyle로 필요하신 부분에 글자 테두리 추가하시면 될 것 같습니다
- FinalSpeakingView()가 기존 화면들과 연결이 잘되었는지 확인 부탁드립니다
- 디자인 변경한 부분 (선택지 간격, VS 테두리) 피드백 부탁드립니다

<br>

## Linked Issue 🔗

- 
