### PR TITLE
[#23]Feat: 랜덤 선택 버튼 클릭 시, 한 바퀴 돌고 선택된 질문으로 scroll되도록 구현

### DIFF
--- a/Balance-Catch-iOS/Balance-Catch-iOS.xcodeproj/project.pbxproj
+++ b/Balance-Catch-iOS/Balance-Catch-iOS.xcodeproj/project.pbxproj
@@ -266,16 +266,16 @@
 				56E2E4AA29C056BE0023095C /* PlayerNumberInputView.swift */,
 				53A7B0AC29C333D300B99211 /* PlayerNameInputView.swift */,
 				53A7B0AE29C334B000B99211 /* SelectQuestionThemeView.swift */,
-				563FBD4A29C9444400847390 /* SelectQuestionView.swift */,
 				3950657829CC93AF00A9C925 /* SelectTypeView.swift */,
+				563FBD4A29C9444400847390 /* SelectQuestionView.swift */,
 				3950657A29CC940700A9C925 /* UserFirstSelectView.swift */,
 				3950657C29CC943B00A9C925 /* TimerView.swift */,
+				39A1561729DC0F7F000968CA /* FirstTeamSpeakingView.swift */,
+				39A1565429E47B96000968CA /* SecondTeamSpeakingView.swift */,
 				3950657E29CC945E00A9C925 /* UserFinalSelectView.swift */,
 				33A83C7E29CA375700C0FA16 /* RecommandOrNotView.swift */,
 				33E60C9629CC1B28005EC0AF /* PublicPickView.swift */,
 				33E60C9E29CC6F3B005EC0AF /* WhoIsLoserView.swift */,
-				39A1561729DC0F7F000968CA /* FirstTeamSpeakingView.swift */,
-				39A1565429E47B96000968CA /* SecondTeamSpeakingView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";

--- a/Balance-Catch-iOS/Balance-Catch-iOS/Custom/WheelStylePicker/QuestionPickerView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/Custom/WheelStylePicker/QuestionPickerView.swift
@@ -7,8 +7,17 @@
 
 import SwiftUI
 
+protocol randomPickAnimation {
+    func scrollToEndIndex() async
+    func scrollToZeroIndex() async
+    func scroll(to index: Int) async
+}
+
 struct QuestionPickerView: View {
     let questions: [Question]
+    let isRandomPick: Bool
+    let serialQueue = DispatchQueue(label: "serialQueue")
+    
     @Binding var selectedIndex: Int
     
     var body: some View {
@@ -25,17 +34,50 @@ struct QuestionPickerView: View {
         }
         .onAppear() {
             let endIndex = selectedIndex
-            selectedIndex = 0
-            for index in 0...endIndex {
-                DispatchQueue.main.asyncAfter(deadline: .now() + Double(index) / 20) {
-                    withAnimation {
-                        selectedIndex = index
-                    }
+            
+            if isRandomPick {
+                Task {
+                    await scrollToEndIndex()
+                    await scrollToZeroIndex()
+                    await scroll(to: endIndex)
                 }
             }
         }
         .pickerStyle(WheelPickerStyle())
         .frame(height: 200)
         .padding([.leading, .trailing], 20)
+    }
+}
+
+extension QuestionPickerView: randomPickAnimation {
+    
+    func scrollToEndIndex() async {
+        selectedIndex = 0
+        for index in 0..<questions.count {
+            serialQueue.asyncAfter(deadline: .now() + Double(index) / 25) {
+                withAnimation {
+                    selectedIndex = index
+                }
+            }
+        }
+    }
+    
+    func scrollToZeroIndex() async {
+        serialQueue.asyncAfter(deadline: .now() + Double(questions.count) / 25 + 0.3) {
+            withAnimation {
+                selectedIndex = 0
+            }
+        }
+    }
+    
+    func scroll(to index: Int) async {
+        let totalEndTime: Double = Double(questions.count) / 25 + 0.6
+        for i in 0...index {
+            serialQueue.asyncAfter(deadline: .now() + totalEndTime + Double(i) / 25) {
+                withAnimation {
+                    selectedIndex = i
+                }
+            }
+        }
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectQuestionView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectQuestionView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct SelectQuestionView: View {
-    
     @State var isRandomPick: Bool
     @State var selectedIndex: Int
     @State var isRetryButtonEnabled = true
@@ -18,24 +17,21 @@ struct SelectQuestionView: View {
     
     init(isRandomPick: Bool, selectedIndex: Int = 0) {
         _isRandomPick = State(initialValue: isRandomPick)
-        _selectedIndex = State(initialValue: isRandomPick ? (0..<questions.count).randomElement()! : 0)
+        _selectedIndex = State(initialValue: isRandomPick ? (0..<questions.count).randomElement() ?? 0 : 0)
     }
     
     var body: some View {
         VStack(spacing: 16) {
             
-            QuestionPickerView(questions: questions, selectedIndex: $selectedIndex)
+            QuestionPickerView(questions: questions,
+                               isRandomPick: isRandomPick,
+                               selectedIndex: $selectedIndex)
                 .id(questionViewId)
             
             HStack(alignment: .center, spacing: 20) {
                 isRandomPick ?
                 Button("Reset") {
-                    isRetryButtonEnabled = false
-                    selectedIndex = (0..<questions.count).randomElement()!
-                    questionViewId = UUID()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                        isRetryButtonEnabled = true
-                    }
+                    tappedResetButton()
                 }
                 .buttonStyle(RoundedBlueButton())
                 .disabled(!isRetryButtonEnabled) : nil
@@ -49,6 +45,15 @@ struct SelectQuestionView: View {
         }
     }
     
+    private func tappedResetButton() {
+        isRetryButtonEnabled = false
+        selectedIndex = (0..<questions.count).randomElement() ?? 0
+        questionViewId = UUID()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            isRetryButtonEnabled = true
+        }
+    }
 }
 
 


### PR DESCRIPTION
## Motivation ⍰

- 랜덤 선택 버튼 클릭 시, 한 바퀴 돌고 선택된 질문으로 scroll되도록 하기 위함

<br>

## Key Changes 🔑

- SelectQuestionView
  - 강제 언래핑 없앰
  - reset 버튼 클릭 이벤트 처리 함수화
  - reset 버튼 클릭 지속시간 3초로 늘림
  - 필요없는 개행 삭제
- QuestionPickerView
  - randomPickAnimation 프로토콜 구현 -> 사용할 함수 직관적으로 알 수 있음
  - 처음 -> 끝 -> 선택된 질문 순으로 순차적으로 스크롤되도록 시차를 설정
  - 각 작업이 순차적으로 진행되도록 async await사용 -> 버벅이는 것을 없애기 위함

<br>

## To Reviewers 🙏🏻

- [x] 랜덤 선택 버튼 클릭 시, 처음 -> 끝 -> 선택된 질문 순으로 스크롤되는지 확인해주세요.
- [x] 직접 고르기를 클릭했을 때 자동으로 스크롤 되는지 확인해주세요.
- 시간 차도 괜찮은지 피드백 주시면 감사요.

<br>

## Linked Issue 🔗

- [x] #23 
