### PR TITLE
[#28]Feat: 마지막 화면에서 New Game 혹은 Replay 클릭 시, 스택 날리기

### DIFF
--- a/Balance-Catch-iOS/Balance-Catch-iOS.xcodeproj/project.pbxproj
+++ b/Balance-Catch-iOS/Balance-Catch-iOS.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		563DF23029E64A0100297A43 /* TimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563DF22F29E64A0100297A43 /* TimerManager.swift */; };
 		563FBD4B29C9444400847390 /* SelectQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563FBD4A29C9444400847390 /* SelectQuestionView.swift */; };
 		563FBD5C29C96F3500847390 /* Question.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563FBD5B29C96F3500847390 /* Question.swift */; };
+		565FCBD729ED149300A27305 /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565FCBD629ED149300A27305 /* Route.swift */; };
 		56807DBB29CAE36E005441D4 /* QuestionTexts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56807DBA29CAE36E005441D4 /* QuestionTexts.swift */; };
 		56930FD329D59861006CEA3F /* QuestionPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56930FD229D59861006CEA3F /* QuestionPickerView.swift */; };
 		56D2730E29CACA6E00E4EF76 /* QuestionItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D2730D29CACA6E00E4EF76 /* QuestionItemView.swift */; };
@@ -105,6 +106,7 @@
 		563DF22F29E64A0100297A43 /* TimerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManager.swift; sourceTree = "<group>"; };
 		563FBD4A29C9444400847390 /* SelectQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectQuestionView.swift; sourceTree = "<group>"; };
 		563FBD5B29C96F3500847390 /* Question.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Question.swift; sourceTree = "<group>"; };
+		565FCBD629ED149300A27305 /* Route.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Route.swift; sourceTree = "<group>"; };
 		56807DBA29CAE36E005441D4 /* QuestionTexts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionTexts.swift; sourceTree = "<group>"; };
 		56930FD229D59861006CEA3F /* QuestionPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionPickerView.swift; sourceTree = "<group>"; };
 		56D2730D29CACA6E00E4EF76 /* QuestionItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionItemView.swift; sourceTree = "<group>"; };
@@ -166,6 +168,7 @@
 		5624C4AC29BFF7CE008C7898 /* Balance-Catch-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				565FCBD529ED148600A27305 /* Route */,
 				56807DB929CAE366005441D4 /* Strings */,
 				563FBD5929C96F1B00847390 /* Model */,
 				56E2E4A729C054350023095C /* View */,
@@ -219,6 +222,14 @@
 				53D1488429D9672C003EAD5A /* PlayerModel.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		565FCBD529ED148600A27305 /* Route */ = {
+			isa = PBXGroup;
+			children = (
+				565FCBD629ED149300A27305 /* Route.swift */,
+			);
+			path = Route;
 			sourceTree = "<group>";
 		};
 		56807DB929CAE366005441D4 /* Strings */ = {
@@ -455,6 +466,7 @@
 				39A1565329E3CB84000968CA /* FinalCircleTimer.swift in Sources */,
 				33E60C9729CC1B28005EC0AF /* PublicPickView.swift in Sources */,
 				56E2E4AB29C056BE0023095C /* PlayerNumberInputView.swift in Sources */,
+				565FCBD729ED149300A27305 /* Route.swift in Sources */,
 				3950658529CC961300A9C925 /* TimerCode.swift in Sources */,
 				5624C4AE29BFF7CE008C7898 /* Balance_Catch_iOSApp.swift in Sources */,
 				33E60C9529CB6768005EC0AF /* RoundedButton.swift in Sources */,
@@ -546,7 +558,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -601,7 +613,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;

--- a/Balance-Catch-iOS/Balance-Catch-iOS/Custom/FinalCircleTimer.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/Custom/FinalCircleTimer.swift
@@ -1,81 +1,81 @@
+////
+////  FinalCircleTimer.swift
+////  Balance-Catch-iOS
+////
+////  Created by 민지은 on 2023/04/10.
+////
 //
-//  FinalCircleTimer.swift
-//  Balance-Catch-iOS
+//import SwiftUI
 //
-//  Created by 민지은 on 2023/04/10.
+//struct FinalCircleTimer: View {
+//    
+//    @State var start = false
+//    @State var to : CGFloat = 0
+//    @State var count = 20 // 최후 변론이라서 시간을 짧게 가져감
+//    @State var time = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+//    @State private var showingAlert = false
+//    @State var tag : Int? = nil
+//    
+//    var body: some View {
+//        
+//        ZStack {
+//            
+//            VStack{
+//                
+//                ZStack{
+//                    Circle() // 전체 시간 원
+//                        .trim(from: 0, to: 1)
+//                        .stroke(Color.black.opacity(0.09), style: StrokeStyle(lineWidth: 35,lineCap: .round))
+//                        .frame(width: 280, height: 280)
+//                    
+//                    Circle() // 시간 줄어드는 원
+//                        .trim(from: 0, to: self.to)
+//                        .stroke(count > 10 ? Color("BalanceCatchBlue") : Color.red, style: StrokeStyle(lineWidth: 35,lineCap: .round)) // 10초 밑으로 떨어지면 색상 변경
+//                        .frame(width: 280, height: 280)
+//                        .rotationEffect(.init(degrees: -90))
+//                    
+//                    VStack{
+//                        Text(String(format:"%02i:%02i",self.count/60,self.count%60))
+//                            .font(.system(size: 65, weight: .bold))
+//                    }
+//                }
+//                
+//                
+//            }
+//            
+//            NavigationLink(destination: UserFinalSelectView(paths: paths), tag: 1, selection: self.$tag ) {}
+//        }
+//        .onReceive(self.time) { (_) in
+//            
+//            if self.count != 0 {
+//                self.count -= 1
+//                
+//                withAnimation(.default){
+//                    self.to = CGFloat(self.count) / 20 // 총 시간 (초) 를 넣어줘야함
+//                    
+//                }
+//            }
+//            if self.count == 0 {
+//                if tag != nil { //tag가 nill이 아닐 경우
+//                    self.showingAlert = false
+//                }else{
+//                    self.showingAlert = true
+//                }
+//            }
+//        }.alert(isPresented: $showingAlert) {
+//            Alert(title: Text("최후 변론 종료!"),
+//                  message: Text("최종 선택으로 넘어갑니다"),
+//                  dismissButton: .default(Text("Close"),
+//                                          action: {
+//                self.tag = 1
+//            }))
+//        }
+//    }
+//}
 //
-
-import SwiftUI
-
-struct FinalCircleTimer: View {
-    
-    @State var start = false
-    @State var to : CGFloat = 0
-    @State var count = 20 // 최후 변론이라서 시간을 짧게 가져감
-    @State var time = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
-    @State private var showingAlert = false
-    @State var tag : Int? = nil
-    
-    var body: some View {
-        
-        ZStack {
-            
-            VStack{
-                
-                ZStack{
-                    Circle() // 전체 시간 원
-                        .trim(from: 0, to: 1)
-                        .stroke(Color.black.opacity(0.09), style: StrokeStyle(lineWidth: 35,lineCap: .round))
-                        .frame(width: 280, height: 280)
-                    
-                    Circle() // 시간 줄어드는 원
-                        .trim(from: 0, to: self.to)
-                        .stroke(count > 10 ? Color("BalanceCatchBlue") : Color.red, style: StrokeStyle(lineWidth: 35,lineCap: .round)) // 10초 밑으로 떨어지면 색상 변경
-                        .frame(width: 280, height: 280)
-                        .rotationEffect(.init(degrees: -90))
-                    
-                    VStack{
-                        Text(String(format:"%02i:%02i",self.count/60,self.count%60))
-                            .font(.system(size: 65, weight: .bold))
-                    }
-                }
-                
-                
-            }
-            
-            NavigationLink(destination: UserFinalSelectView(), tag: 1, selection: self.$tag ) {}
-        }
-        .onReceive(self.time) { (_) in
-            
-            if self.count != 0 {
-                self.count -= 1
-                
-                withAnimation(.default){
-                    self.to = CGFloat(self.count) / 20 // 총 시간 (초) 를 넣어줘야함
-                    
-                }
-            }
-            if self.count == 0 {
-                if tag != nil { //tag가 nill이 아닐 경우
-                    self.showingAlert = false
-                }else{
-                    self.showingAlert = true
-                }
-            }
-        }.alert(isPresented: $showingAlert) {
-            Alert(title: Text("최후 변론 종료!"),
-                  message: Text("최종 선택으로 넘어갑니다"),
-                  dismissButton: .default(Text("Close"),
-                                          action: {
-                self.tag = 1
-            }))
-        }
-    }
-}
-
-
-struct FinalCircleTimer_Previews: PreviewProvider {
-    static var previews: some View {
-        FinalCircleTimer()
-    }
-}
+//
+//struct FinalCircleTimer_Previews: PreviewProvider {
+//    static var previews: some View {
+//        FinalCircleTimer()
+//    }
+//}

--- a/Balance-Catch-iOS/Balance-Catch-iOS/Route/Route.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/Route/Route.swift
@@ -1,0 +1,23 @@
+//
+//  Route.swift
+//  Balance-Catch-iOS
+//
+//  Created by SeungMin on 2023/04/17.
+//
+
+enum Route: Hashable {
+    case beforePlayRuleDescriptionView
+    case playerNumberInputView
+    case playerNameInputView(numberOfPeople: Int)
+    case selectQuestionThemeView
+    case selectTypeView
+    case selectQuestionView(isRandomPick: Bool)
+    case userFirstSelectView(selectedQuestion: Question)
+    case timerView
+    case firstTeamSpeakingView
+    case secondTeamSpeakingView
+    case userFinalSelectView
+    case recommandOrNotView
+    case publicPickView
+    case whoIsLoserView
+}

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/BeforePlayRuleDescriptionView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/BeforePlayRuleDescriptionView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct BeforePlayRuleDescriptionView: View {
+    @Binding var path: [Route]
+    
     var body: some View {
         GeometryReader { geometry in
             ZStack(alignment: .center) {
@@ -19,17 +21,14 @@ struct BeforePlayRuleDescriptionView: View {
                     
                     Spacer()
                     
-                    NavigationLink("Next") {
-                        PlayerNumberInputView()
-                    }
-                    .buttonStyle(RoundedBlueButton())
+                    NavigationLink("Next", value: Route.playerNumberInputView)
+                        .buttonStyle(RoundedBlueButton())
                     
                     Spacer()
                 }
                 .frame (width: geometry.size.width * 0.9)
                 .background(RoundedRectangle(cornerRadius: 20).stroke(.balanceCatchBlue, lineWidth: 4))
                 .frame (width: geometry.size.width, height: geometry.size.height)
-                
             }
         }
     }
@@ -37,6 +36,6 @@ struct BeforePlayRuleDescriptionView: View {
 
 struct BeforePlayRuleDescriptionView_Previews: PreviewProvider {
     static var previews: some View {
-        BeforePlayRuleDescriptionView()
+        BeforePlayRuleDescriptionView(path: Binding.constant([]))
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/FirstTeamSpeakingView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/FirstTeamSpeakingView.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct FirstTeamSpeakingView: View {
+    @Binding var path: [Route]
     
     @State var isStartButtonPressed = false
-    @State var isNextButtonPressed = false
-    
+    @State var circleTimerId = UUID()
     
     var body: some View{
         
@@ -30,8 +30,8 @@ struct FirstTeamSpeakingView: View {
                     .font(.system(size:28))
                     .fontWeight(.bold)
                     .shadow(color:.gray,radius:3,x:2,y:2)
-            
-               Text("제리") // 나중에 질문 값 받아와야 함
+                
+                Text("제리") // 나중에 질문 값 받아와야 함
                     .font(.system(size: 22, weight: .bold))
                     .minimumScaleFactor(0.5)
                     .padding(.bottom, 10)
@@ -48,27 +48,26 @@ struct FirstTeamSpeakingView: View {
                 
             }.padding(.bottom, 40)
             
-            CircleTimer(timerManager: TimerManager(counter: 15),
-                        isStartButtonPressed: $isStartButtonPressed,
-                        isNextButtonPressed: $isNextButtonPressed,
-                        alertMessageType: .firstTeam)
-            .id(UUID())
+            CircleTimer(timerManager: TimerManager(totalTime: 15),
+                        nextPath: Route.secondTeamSpeakingView,
+                        alertMessageType: .firstTeam,
+                        isStartButtonPressed: $isStartButtonPressed)
+            .id(circleTimerId)
             .padding(.bottom, 50)
             
-            Button(isStartButtonPressed ? "Next" : "Start") {
-                if(!self.isStartButtonPressed){
+            if !isStartButtonPressed {
+                Button("Start") {
                     self.isStartButtonPressed = true
-                } else {
-                    self.isNextButtonPressed = true
+                    circleTimerId = UUID()
                 }
+                .buttonStyle(RoundedBlueButton())
+            } else {
+                NavigationLink("Next", value: Route.secondTeamSpeakingView)
+                    .buttonStyle(RoundedBlueButton())
             }
-            .buttonStyle(RoundedBlueButton())
-            
-            NavigationLink("", destination: SecondTeamSpeakingView(), isActive: $isNextButtonPressed)
         }//Vstack
         .onAppear() {
             isStartButtonPressed = false
-            isNextButtonPressed = false
         }
         
         Spacer()
@@ -80,6 +79,6 @@ struct FirstTeamSpeakingView: View {
 
 struct FirstTeamSpeakingView_Previews: PreviewProvider {
     static var previews: some View {
-        FirstTeamSpeakingView()
+        FirstTeamSpeakingView(path: Binding.constant([]))
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/LaunchScreenView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/LaunchScreenView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct LaunchScreenView: View {
+    @State private var path: [Route] = []
+    
     init() {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithTransparentBackground()
@@ -16,22 +18,53 @@ struct LaunchScreenView: View {
     }
     
     var body: some View {
-        GeometryReader { geometry in
-            NavigationView {
-                ZStack(alignment: .center) {
-                    Color.white
-                    VStack {
-                        Image(.logo)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: geometry.size.width / 2,
-                                   alignment: .center)
-                            .padding(.bottom, 74)
-                        NavigationLink("Start!") {
-                            BeforePlayRuleDescriptionView()
-                        }
+        NavigationStack(path: $path) {
+            ZStack(alignment: .center) {
+                Color.white
+                VStack {
+                    Image(.logo)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: CGFloat.superViewFrameWidth / 2,
+                               alignment: .center)
+                        .padding(.bottom, 74)
+                    NavigationLink("Start!", value: Route.beforePlayRuleDescriptionView)
                         .buttonStyle(RoundedBlueButton())
-                    }
+                }
+            }
+            .navigationDestination(for: Route.self) { route in
+                switch route {
+                case .beforePlayRuleDescriptionView:
+                    BeforePlayRuleDescriptionView(path: $path)
+                case .playerNumberInputView:
+                    PlayerNumberInputView(path: $path)
+                case .playerNameInputView(let numberOfPeople):
+                    PlayerNameInputView(numberOfPeople: numberOfPeople,
+                                        path: $path)
+                case .selectQuestionThemeView:
+                    SelectQuestionThemeView(path: $path)
+                case .selectTypeView:
+                    SelectTypeView(selectedTheme: "", path: $path)
+                case .selectQuestionView(let isRandomPick):
+                    SelectQuestionView(isRandomPick: isRandomPick,
+                                       path: $path)
+                case .userFirstSelectView(let selectedQuestion):
+                    UserFirstSelectView(selectedQuestion: selectedQuestion,
+                                        path: $path)
+                case .timerView:
+                    TimerView(path: $path)
+                case .firstTeamSpeakingView:
+                    FirstTeamSpeakingView(path: $path)
+                case .secondTeamSpeakingView:
+                    SecondTeamSpeakingView(path: $path)
+                case .userFinalSelectView:
+                    UserFinalSelectView(path: $path)
+                case .recommandOrNotView:
+                    RecommandOrNotView(path: $path)
+                case .publicPickView:
+                    PublicPickView(path: $path)
+                case .whoIsLoserView:
+                    WhoIsLoserView(path: $path)
                 }
             }
         }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/PlayerNameInputView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/PlayerNameInputView.swift
@@ -11,6 +11,7 @@ struct PlayerNameInputView: View {
     @State public var numberOfPeople: Int
     @State private var playerNames: [String] = []
     @State private var scrollViewHeight: CGFloat = 0
+    @Binding var path: [Route]
     
     @ObservedObject var playerList = PlayerList()
     
@@ -72,10 +73,8 @@ struct PlayerNameInputView: View {
                 if scrollViewHeight == ViewHeightKey.maxValue { Spacer() }
                 else { Spacer().frame(height: 34) }
                 
-                NavigationLink(destination: SelectQuestionThemeView()) {
-                    Text("Next")
-                }
-                .buttonStyle(RoundedBlueButton())
+                NavigationLink("Next", value: Route.selectQuestionThemeView)
+                    .buttonStyle(RoundedBlueButton())
             }
         }
         .onAppear {
@@ -95,6 +94,6 @@ struct ViewHeightKey: PreferenceKey {
 
 struct PlayerNameInputView_Previews: PreviewProvider {
     static var previews: some View {
-        PlayerNameInputView(numberOfPeople: 5)
+        PlayerNameInputView(numberOfPeople: 5, path: Binding.constant([]))
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/PlayerNumberInputView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/PlayerNumberInputView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct PlayerNumberInputView: View {
     @State private var numberOfPeople = 2
     @State private var showAlert = false
+    @Binding var path: [Route]
     
     var body: some View {
         ZStack {
@@ -30,23 +31,21 @@ struct PlayerNumberInputView: View {
                     .padding(.horizontal, 45.0)
                     .padding(.vertical, 27.0)
                 
-                NavigationLink(destination: PlayerNameInputView(numberOfPeople: numberOfPeople)) {
-                    Text("Next")
-                }
-                .buttonStyle(RoundedBlueButton())
-                .disabled(numberOfPeople <= 0)
-                .alert(isPresented: $showAlert) {
-                    Alert(
-                        title: Text("인원 수 부족"),
-                        message: Text("인원 수에 0이하의 값을 넣었습니다."),
-                        dismissButton: .default(Text("OK"))
-                    )
-                }
-                .onTapGesture {
-                    if numberOfPeople <= 0 {
-                        showAlert = true
+                NavigationLink("Next", value: Route.playerNameInputView(numberOfPeople: numberOfPeople))
+                    .buttonStyle(RoundedBlueButton())
+                    .disabled(numberOfPeople <= 0)
+                    .alert(isPresented: $showAlert) {
+                        Alert(
+                            title: Text("인원 수 부족"),
+                            message: Text("인원 수에 0이하의 값을 넣었습니다."),
+                            dismissButton: .default(Text("OK"))
+                        )
                     }
-                }
+                    .onTapGesture {
+                        if numberOfPeople <= 0 {
+                            showAlert = true
+                        }
+                    }
             }
         }
     }
@@ -54,6 +53,6 @@ struct PlayerNumberInputView: View {
 
 struct PlayerNumberInputView_Previews: PreviewProvider {
     static var previews: some View {
-        PlayerNumberInputView()
+        PlayerNumberInputView(path: Binding.constant([]))
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/PublicPickView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/PublicPickView.swift
@@ -8,12 +8,12 @@
 import SwiftUI
 
 struct PublicPickView: View {
-    
     @State private var animationAmount:CGFloat = 1
     @State private var firstAmount : Double = 30.0
     @State private var secondAmount : Double = 70.0
     @State private var firstIncreAmount : Double = 0.0
     @State private var secondIncreAmount : Double = 0.0
+    @Binding var path: [Route]
     
     func whatIsPick(firstPer:Int,secondPer:Int )->Double
     {
@@ -115,10 +115,8 @@ struct PublicPickView: View {
             
             
             ZStack {
-                NavigationLink("Next") {
-                    WhoIsLoserView()
-                }
-                .buttonStyle(RoundedBlueButton())
+                NavigationLink("Next", value: Route.whoIsLoserView)
+                    .buttonStyle(RoundedBlueButton())
             }
         }
     }
@@ -126,6 +124,6 @@ struct PublicPickView: View {
 
 struct PublicPickView_Previews: PreviewProvider {
     static var previews: some View {
-        PublicPickView()
+        PublicPickView(path: Binding.constant([]))
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/RecommandOrNotView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/RecommandOrNotView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct RecommandOrNotView: View {
     @State  var tag:Int? = nil
+    @Binding var path: [Route]
+    
     var body: some View {
         VStack{
             
@@ -23,33 +25,25 @@ struct RecommandOrNotView: View {
             
             HStack{
                 ZStack{
-                    NavigationLink(destination: PublicPickView()){
-                        Text("👍🏻")
-                            .font(.system(size: 35, weight: .bold))
-                        let _ = print("좋아요")
-            
-                    }
-                       
-                    .buttonStyle(RoundedButton())
+                    NavigationLink("👍🏻", value: Route.publicPickView)
+                        .font(.system(size: 35, weight: .bold))
+                        .buttonStyle(RoundedButton())
                 }
                 
                 ZStack{
-                    NavigationLink(destination: PublicPickView()){
-                        Text("👎🏻")
-                            .font(.system(size: 35, weight: .bold))
-                        let _ = print("싫어요")
-                    }
-                    .buttonStyle(RoundedButton())
+                    NavigationLink("👎🏻", value: Route.publicPickView)
+                        .font(.system(size: 35, weight: .bold))
+                        .buttonStyle(RoundedButton())
                 }
                 
             }
-
+            
         }
     }
 }
 
 struct RecommandOrNotView_Previews: PreviewProvider {
     static var previews: some View {
-        RecommandOrNotView()
+        RecommandOrNotView(path: Binding.constant([]))
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/SecondTeamSpeakingView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/SecondTeamSpeakingView.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct SecondTeamSpeakingView: View {
+    @Binding var path: [Route]
     
     @State var isStartButtonPressed = false
-    @State var isNextButtonPressed = false
-    
+    @State var circleTimerId = UUID()
     
     var body: some View{
         
@@ -48,27 +48,26 @@ struct SecondTeamSpeakingView: View {
                 
             }.padding(.bottom, 40)
             
-            CircleTimer(timerManager: TimerManager(counter: 15),
-                        isStartButtonPressed: $isStartButtonPressed,
-                        isNextButtonPressed: $isNextButtonPressed,
-                        alertMessageType: .secondTeam)
-            .id(UUID())
+            CircleTimer(timerManager: TimerManager(totalTime: 15),
+                        nextPath: Route.userFinalSelectView,
+                        alertMessageType: .secondTeam,
+                        isStartButtonPressed: $isStartButtonPressed)
+            .id(circleTimerId)
             .padding(.bottom, 50)
             
-            Button(isStartButtonPressed ? "Next" : "Start") {
-                if(!self.isStartButtonPressed){
+            if !isStartButtonPressed {
+                Button("Start") {
                     self.isStartButtonPressed = true
-                } else {
-                    self.isNextButtonPressed = true
+                    circleTimerId = UUID()
                 }
+                .buttonStyle(RoundedBlueButton())
+            } else {
+                NavigationLink("Next", value: Route.userFinalSelectView)
+                    .buttonStyle(RoundedBlueButton())
             }
-            .buttonStyle(RoundedBlueButton())
-            
-            NavigationLink("", destination: UserFinalSelectView(), isActive: $isNextButtonPressed)
         }//Vstack
         .onAppear() {
             isStartButtonPressed = false
-            isNextButtonPressed = false
         }
         
         Spacer()
@@ -80,6 +79,6 @@ struct SecondTeamSpeakingView: View {
 
 struct SecondTeamSpeakingView_Previews: PreviewProvider {
     static var previews: some View {
-        SecondTeamSpeakingView()
+        SecondTeamSpeakingView(path: Binding.constant([]))
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectQuestionThemeView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectQuestionThemeView.swift
@@ -10,16 +10,17 @@ import SwiftUI
 struct SelectQuestionThemeView: View {
     let questionThemes = ["커플", "직장인", "솔로", "음식", "학생", "극과극", "생활"]
     @State private var selectedTheme: String = ""
-
+    @Binding var path: [Route]
+    
     var body: some View {
         VStack {
             Text("질문 테마를 선택 해주세요")
                 .font(Font.custom("Arial", size: 24))
                 .fontWeight(.bold)
                 .shadow(color:.gray,radius:2,x:3,y:3)
-
+            
             Spacer()
-
+            
             ScrollView {
                 LazyVStack(spacing: 20) {
                     ForEach(questionThemes, id: \.self) { theme in
@@ -35,15 +36,12 @@ struct SelectQuestionThemeView: View {
                 }
                 .padding()
             }
-
+            
             Spacer()
             
-            NavigationLink(destination: SelectTypeView(selectedTheme: selectedTheme)) {
-                let _ = print(selectedTheme)
-                Text("Next")
-            }
-            .buttonStyle(RoundedBlueButton())
-            .disabled(selectedTheme.isEmpty)
+            NavigationLink("Next", value: Route.selectTypeView)
+                .buttonStyle(RoundedBlueButton())
+                .disabled(selectedTheme.isEmpty)
         }
         .padding()
     }
@@ -52,6 +50,6 @@ struct SelectQuestionThemeView: View {
 
 struct SelectQuestionThemeView_Previews: PreviewProvider {
     static var previews: some View {
-        return SelectQuestionThemeView()
+        return SelectQuestionThemeView(path: Binding.constant([]))
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectQuestionView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectQuestionView.swift
@@ -12,35 +12,36 @@ struct SelectQuestionView: View {
     @State var selectedIndex: Int
     @State var isRetryButtonEnabled = true
     @State var questionViewId = UUID()
+    @Binding var path: [Route]
     
     var questions: [Question] = getNewQuestionList()
     
-    init(isRandomPick: Bool, selectedIndex: Int = 0) {
+    init(isRandomPick: Bool, selectedIndex: Int = 0, path: Binding<[Route]>) {
         _isRandomPick = State(initialValue: isRandomPick)
         _selectedIndex = State(initialValue: isRandomPick ? (0..<questions.count).randomElement() ?? 0 : 0)
+        _path = path
     }
     
     var body: some View {
         VStack(spacing: 16) {
-            
             QuestionPickerView(questions: questions,
                                isRandomPick: isRandomPick,
                                selectedIndex: $selectedIndex)
-                .id(questionViewId)
+            .id(questionViewId)
             
             HStack(alignment: .center, spacing: 20) {
                 isRandomPick ?
                 Button("Reset") {
+                    questionViewId = UUID()
                     tappedResetButton()
                 }
                 .buttonStyle(RoundedBlueButton())
                 .disabled(!isRetryButtonEnabled) : nil
                 
-                NavigationLink("Next") {
-                    UserFirstSelectView(selectedQuestion: questions[selectedIndex])
-                }
+                NavigationLink("Next",
+                               value:
+                                Route.userFirstSelectView(selectedQuestion: questions[selectedIndex]))
                 .buttonStyle(RoundedBlueButton())
-                
             }
         }
     }
@@ -48,7 +49,6 @@ struct SelectQuestionView: View {
     private func tappedResetButton() {
         isRetryButtonEnabled = false
         selectedIndex = (0..<questions.count).randomElement() ?? 0
-        questionViewId = UUID()
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
             isRetryButtonEnabled = true
@@ -70,6 +70,6 @@ func getNewQuestionList() -> [Question] {
 
 struct SelectQuestionView_Previews: PreviewProvider {
     static var previews: some View {
-        SelectQuestionView(isRandomPick: true)
+        SelectQuestionView(isRandomPick: true, path: Binding.constant([]))
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectTypeView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectTypeView.swift
@@ -8,7 +8,9 @@
 import SwiftUI
 
 struct SelectTypeView: View {
-    @State public var selectedTheme: String
+    @State
+    public var selectedTheme: String
+    @Binding var path: [Route]
     
     @State
     private var isActivated1: Bool = false
@@ -16,7 +18,7 @@ struct SelectTypeView: View {
     private var isActivated2: Bool = false
     
     var body: some View {
-        let _ = print("이동 후: " + selectedTheme)
+        //        let _ = print("이동 후: " + selectedTheme)
         VStack{
             
             
@@ -49,11 +51,8 @@ struct SelectTypeView: View {
             .buttonStyle(SelectButton(isActivated: $isActivated2))
             
             
-            NavigationLink {
-                SelectQuestionView(isRandomPick: isActivated1)
-            } label: {
-                Text("Next")
-            }
+            NavigationLink("Next",
+                           value: Route.selectQuestionView(isRandomPick: isActivated1))
             .padding(.top, 27)
             .buttonStyle(RoundedBlueButton())
             .disabled(!isActivated1 && !isActivated2)
@@ -63,6 +62,6 @@ struct SelectTypeView: View {
 
 struct SelectTypeView_Previews: PreviewProvider {
     static var previews: some View {
-        SelectTypeView(selectedTheme:"커플")
+        SelectTypeView(selectedTheme:"커플", path: Binding.constant([]))
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/TimerView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/TimerView.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct TimerView: View {
+    @Binding var path: [Route]
     
     @State var isStartButtonPressed = false
-    @State var isNextButtonPressed = false
-    
+    @State var circleTimerId = UUID()
     
     var body: some View{
         
@@ -22,27 +22,26 @@ struct TimerView: View {
                 .shadow(color:.gray,radius:2,x:3,y:3)
                 .padding(.bottom, 45)
             
-            CircleTimer(timerManager: TimerManager(counter: 25),
-                        isStartButtonPressed: $isStartButtonPressed,
-                        isNextButtonPressed: $isNextButtonPressed,
-                        alertMessageType: .whole)
-            .id(UUID())
+            CircleTimer(timerManager: TimerManager(totalTime: 25),
+                        nextPath: Route.firstTeamSpeakingView,
+                        alertMessageType: .whole,
+                        isStartButtonPressed: $isStartButtonPressed)
+            .id(circleTimerId)
             .padding(.bottom, 50)
             
-            Button(isStartButtonPressed ? "Next" : "Start") {
-                if(!self.isStartButtonPressed){
+            if !isStartButtonPressed {
+                Button("Start") {
                     self.isStartButtonPressed = true
-                } else {
-                    self.isNextButtonPressed = true
+                    circleTimerId = UUID()
                 }
+                .buttonStyle(RoundedBlueButton())
+            } else {
+                NavigationLink("Next", value: Route.firstTeamSpeakingView)
+                    .buttonStyle(RoundedBlueButton())
             }
-            .buttonStyle(RoundedBlueButton())
-            
-            NavigationLink("", destination: FirstTeamSpeakingView(), isActive: $isNextButtonPressed)
         }//Vstack
         .onAppear() {
             isStartButtonPressed = false
-            isNextButtonPressed = false
         }
     }
 }
@@ -50,6 +49,6 @@ struct TimerView: View {
 
 struct TimerView_Previews: PreviewProvider {
     static var previews: some View {
-        TimerView()
+        TimerView(path: Binding.constant([]))
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFinalSelectView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFinalSelectView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct UserFinalSelectView: View {
+    @Binding var path: [Route]
     
     @State private var isActivated1: Bool = false
     @State private var isActivated2: Bool = false
@@ -99,10 +100,8 @@ struct UserFinalSelectView: View {
                     .padding(.bottom, 25)
             }
             
-            NavigationLink("Next") {
-                RecommandOrNotView()
-            }
-            .buttonStyle(RoundedBlueButton())
+            NavigationLink("Next", value: Route.recommandOrNotView)
+                .buttonStyle(RoundedBlueButton())
         }
         .task {
             withAnimation(.easeInOut(duration: 1)) {
@@ -116,6 +115,6 @@ struct UserFinalSelectView: View {
 
 struct UserFinalSelect_Previews: PreviewProvider {
     static var previews: some View {
-        UserFinalSelectView()
+        UserFinalSelectView(path: Binding.constant([]))
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFirstSelectView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFirstSelectView.swift
@@ -10,29 +10,32 @@ import Foundation
 
 struct UserFirstSelectView: View {
     let selectedQuestion: Question
+    @Binding var path: [Route]
+    
     @State private var isActivated1: Bool = false
     @State private var isActivated2: Bool = false
     @State var showingSubview = false
     
     
-    init(selectedQuestion: Question) {
+    init(selectedQuestion: Question, path: Binding<[Route]>) {
         self.selectedQuestion = selectedQuestion
         questionArray = selectedQuestion.text.components(separatedBy: "vs")
+        _path = path
     }
     
     var questionArray: [String]
-  
+    
     mutating func onAppear() {
         questionArray = selectedQuestion.text.components(separatedBy: "vs")
     }
     
     var first: String {
-            questionArray.first ?? ""
+        questionArray.first ?? ""
     }
     var second: String {
         questionArray.last ?? ""
     }
-
+    
     var body: some View {
         VStack{
             Text("1차 선택")
@@ -106,7 +109,7 @@ struct UserFirstSelectView: View {
                             .padding(.trailing, 35)
                             .padding(.bottom, 10)
                             .padding(.top, 10)
-
+                        
                             .frame(width:250,height:150)
                         
                     }
@@ -128,10 +131,8 @@ struct UserFirstSelectView: View {
                 
             }
             
-            NavigationLink("Next") {
-                TimerView()
-            }
-            .buttonStyle(RoundedBlueButton())
+            NavigationLink("Next", value: Route.timerView)
+                .buttonStyle(RoundedBlueButton())
         }
         .task {
             withAnimation(.easeInOut(duration: 1)) {
@@ -147,6 +148,6 @@ struct UserFirstSelectView: View {
 
 struct UserFirstSelect_Previews: PreviewProvider {
     static var previews: some View {
-        UserFirstSelectView(selectedQuestion: .init(text: "test"))
+        UserFirstSelectView(selectedQuestion: .init(text: "test"), path: Binding.constant([]))
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/WhoIsLoserView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/WhoIsLoserView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct WhoIsLoserView: View {
+    @Binding var path: [Route]
+    
     var body: some View {
         VStack
         {
@@ -49,28 +51,32 @@ struct WhoIsLoserView: View {
             }
             .padding(.bottom,56)
             
-            // 고치기~~~~~~~~~~~~~~~~  
+            // 고치기~~~~~~~~~~~~~~~~
             HStack{
-                ZStack {
-                    NavigationLink("New Game") {
-                        
-                    }
-                    .buttonStyle(BiggerRoundedBlueButton())
+                Button("New Game") {
+                    moveToPlayerNumberInputView()
                 }
-                ZStack {
-                    NavigationLink("Replay") {
-                        SelectQuestionThemeView()
-                    }
-                    .buttonStyle(BiggerRoundedBlueButton())
+                .buttonStyle(BiggerRoundedBlueButton())
+                Button("Replay") {
+                    moveToSelectTypeView()
                 }
+                .buttonStyle(BiggerRoundedBlueButton())
             }
         }
         
+    }
+    
+    private func moveToPlayerNumberInputView() {
+        path.removeLast(12)
+    }
+    
+    private func moveToSelectTypeView() {
+        path.removeLast(9)
     }
 }
 
 struct WhoIsLoserView_Previews: PreviewProvider {
     static var previews: some View {
-        WhoIsLoserView()
+        WhoIsLoserView(path: Binding.constant([]))
     }
 }


### PR DESCRIPTION
## Motivation ⍰

- [ ] NavigationView -> NavigationStack으로 변경 => 스택을 한 번에 지우기 위함
- [ ] 그래서 최소 iOS 버전 16.0이상으로 변경
- [ ] Route enum 정의 -> 모든 뷰 케이스 정의를 위함
- [ ] root view에서는 path State, 다른 뷰에서 path Binding 변수 정의 -> stack을 쌓고 지우기 위함
- [ ] back, push하는 과정에서 화면을 반복해서 그리게 되고 timer가 다시 도는 현상 수정 -> start버튼 클릭 시에만 id갱신
- [ ] 타이머는 한 번만 그려지도록 수정 -> 원래는 2번씩 그려지고 있었음
- [ ] 마지막 화면에서 New Game 클릭 시, 인원수 선택 화면으로 이동, Replay 버튼 클릭 시, 질문 랜덤 or 고르기 화면으로 이동
- [ ] 불필요한 개행 삭제 및 자동 들여쓰기 적용

<br>

## Key Changes 🔑

- root view에서는 path State, 다른 뷰에서 path Binding 변수 정의
- Replay 버튼 클릭 시, 질문 랜덤 or 고르기 화면으로 이동
- 화면을 지울 때 remove보다 남아있는 화면들로 초기화를 하려고 했으나, 화면마다 파라미터들이 있어서 Remove를 선택함
코드는 다음과 같음
```swift
 var body: some View {
      { ... }
      HStack{
          Button("New Game") {
              moveToPlayerNumberInputView()
          }
          .buttonStyle(BiggerRoundedBlueButton())
          Button("Replay") {
              moveToSelectTypeView()
          }
          .buttonStyle(BiggerRoundedBlueButton())
      }
  }
  
  private func moveToPlayerNumberInputView() {
      path.removeLast(12)
  }
  
  private func moveToSelectTypeView() {
      path.removeLast(9)
  }
```

<br>

## To Reviewers 🙏🏻

- [x] 마지막 화면에서 New Game, Replay 버튼이 잘 동작하는지 확인해주세요
- [x] 타이머가 있는 화면에서 뒤로갔다가 다시 돌아온 상태에서 start 후, 타이머가 두 번 돌지는 않는지 확인해주세요
- [x] 왼쪽 오른쪽 선택할 때 애니메이션 오류가 없는 지 확인해주세요
- [ ] path 바인딩 변수를 쓰다보니 다른 화면들도 여러번 다시 그려질 수 있는데, 기존이랑 달라진 것이 없는지 확인해주세요

<br>

## Linked Issue 🔗

- [x] #28 
