### PR TITLE
[#31]Bug: 질문 랜덤 배정 버튼 클릭 후 바로 next를 눌렀을 때 텍스트가 랜덤으로 바뀌는 현상 수정

### DIFF
--- a/Balance-Catch-iOS/Balance-Catch-iOS/Custom/WheelStylePicker/QuestionPickerView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/Custom/WheelStylePicker/QuestionPickerView.swift
@@ -29,7 +29,6 @@ struct QuestionPickerView: View {
                             selectedIndex = index
                         }
                     }
-                    .id(questions[index])
             }
         }
         .onAppear() {

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectQuestionView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectQuestionView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SelectQuestionView: View {
     @State var isRandomPick: Bool
     @State var selectedIndex: Int
-    @State var isRetryButtonEnabled = true
+    @State var isRetryButtonEnabled = false
     @State var questionViewId = UUID()
     @Binding var path: [Route]
     
@@ -30,18 +30,30 @@ struct SelectQuestionView: View {
             .id(questionViewId)
             
             HStack(alignment: .center, spacing: 20) {
-                isRandomPick ?
-                Button("Reset") {
-                    questionViewId = UUID()
-                    tappedResetButton()
-                }
-                .buttonStyle(RoundedBlueButton())
-                .disabled(!isRetryButtonEnabled) : nil
+                if isRandomPick {
+                    Button("Reset") {
+                        questionViewId = UUID()
+                        tappedResetButton()
+                    }
+                    .buttonStyle(RoundedBlueButton())
+                    .disabled(!isRetryButtonEnabled)
+                } else { EmptyView() }
                 
-                NavigationLink("Next",
-                               value:
-                                Route.userFirstSelectView(selectedQuestion: questions[selectedIndex]))
-                .buttonStyle(RoundedBlueButton())
+                if !isRetryButtonEnabled {
+                    Button("Next") { }
+                        .buttonStyle(RoundedBlueButton())
+                } else {
+                    NavigationLink("Next",
+                                   value:
+                                    Route.userFirstSelectView(selectedQuestion: questions[selectedIndex]))
+                    .buttonStyle(RoundedBlueButton())
+                }
+            }
+        }
+        .onAppear() {
+            isRetryButtonEnabled = false
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                isRetryButtonEnabled = true
             }
         }
     }
@@ -55,7 +67,6 @@ struct SelectQuestionView: View {
         }
     }
 }
-
 
 func getNewQuestionList() -> [Question] {
     let qustionTexts = QuestionTexts().list


### PR DESCRIPTION
## Motivation ⍰

- 재시도 버튼 클릭 시, Next버튼 3초 비활성화
- 질문 선택 화면에 들어왔을 때, 재시도 버튼을 바로 누를 수 없도록 처음에도 3초 비활성화

<br>

## Key Changes 🔑

```swift
// SelectQuestionView
var body: some View {
    VStack(spacing: 16) {
        { ... }
        
        HStack(alignment: .center, spacing: 20) {
            { ... }
            
            if !isRetryButtonEnabled {
                Button("Next") { } // isRetryButtonEnabled false일 때, 클릭 액션 없음
                    .buttonStyle(RoundedBlueButton())
            } else {
                NavigationLink("Next",
                               value:
                                Route.userFirstSelectView(selectedQuestion: questions[selectedIndex]))
                .buttonStyle(RoundedBlueButton())
            }
        }
    }
    // 해당 화면으로 다시 돌아왔을 때 버튼을 false로 초기화
    .onAppear() {
        isRetryButtonEnabled = false
        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
            isRetryButtonEnabled = true
        }
    }
}
```

<br>

## To Reviewers 🙏🏻

- [x] 재시도 버튼 클릭 시, **Next버튼이 3초 동안 비활성화**되는지 확인해주세요.
- [x] 질문 선택 화면에 들어왔을 때, **재시도 버튼**을 바로 누를 수 없도록 처음에도 **3초 비활성화**(뒤로가기로 돌아왔을 때도)

<br>

## Linked Issue 🔗

- [x] #31 
