### PR TITLE
Player 수 만큼 선택지 화면 구현

### DIFF
--- a/Balance-Catch-iOS/Balance-Catch-iOS.xcodeproj/project.pbxproj
+++ b/Balance-Catch-iOS/Balance-Catch-iOS.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		3950658129CC949600A9C925 /* SelectBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3950658029CC949600A9C925 /* SelectBox.swift */; };
 		3950658329CC94AF00A9C925 /* SelectButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3950658229CC94AF00A9C925 /* SelectButton.swift */; };
 		3950658529CC961300A9C925 /* TimerCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3950658429CC961300A9C925 /* TimerCode.swift */; };
+		3993D76C2A20E3EA006821B6 /* UserQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3993D76B2A20E3EA006821B6 /* UserQuestion.swift */; };
 		39A1561829DC0F7F000968CA /* FirstTeamSpeakingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A1561729DC0F7F000968CA /* FirstTeamSpeakingView.swift */; };
 		39A1561A29DC1899000968CA /* StorkeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A1561929DC1899000968CA /* StorkeText.swift */; };
 		39A1565129DE4846000968CA /* CircleTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A1565029DE4846000968CA /* CircleTimer.swift */; };
@@ -84,6 +85,7 @@
 		3950658029CC949600A9C925 /* SelectBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectBox.swift; sourceTree = "<group>"; };
 		3950658229CC94AF00A9C925 /* SelectButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectButton.swift; sourceTree = "<group>"; };
 		3950658429CC961300A9C925 /* TimerCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerCode.swift; sourceTree = "<group>"; };
+		3993D76B2A20E3EA006821B6 /* UserQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserQuestion.swift; sourceTree = "<group>"; };
 		39A1561729DC0F7F000968CA /* FirstTeamSpeakingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstTeamSpeakingView.swift; sourceTree = "<group>"; };
 		39A1561929DC1899000968CA /* StorkeText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorkeText.swift; sourceTree = "<group>"; };
 		39A1565029DE4846000968CA /* CircleTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleTimer.swift; sourceTree = "<group>"; };
@@ -226,6 +228,7 @@
 			children = (
 				563FBD5B29C96F3500847390 /* Question.swift */,
 				53D1488429D9672C003EAD5A /* PlayerModel.swift */,
+				3993D76B2A20E3EA006821B6 /* UserQuestion.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -446,6 +449,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				56930FD329D59861006CEA3F /* QuestionPickerView.swift in Sources */,
+				3993D76C2A20E3EA006821B6 /* UserQuestion.swift in Sources */,
 				3950657D29CC943B00A9C925 /* TimerView.swift in Sources */,
 				33FCD2AB29E07AFD006E2131 /* CustomProgressView.swift in Sources */,
 				39A1561A29DC1899000968CA /* StorkeText.swift in Sources */,

--- a/Balance-Catch-iOS/Balance-Catch-iOS/Balance_Catch_iOSApp.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/Balance_Catch_iOSApp.swift
@@ -10,11 +10,13 @@ import SwiftUI
 @main
 struct Balance_Catch_iOSApp: App {
     @StateObject var playerList = PlayerList(players: [])
+    @StateObject var userQuestion = UserQuestion()
     
     var body: some Scene {
         WindowGroup {
             LaunchScreenView()
                 .environmentObject(playerList)
+                .environmentObject(userQuestion)
         }
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/Custom/Timer/CircleTimer.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/Custom/Timer/CircleTimer.swift
@@ -74,7 +74,7 @@ struct CircleTimer: View {
                 presenting: alertMessageType) { _ in
             NavigationLink("Close", value: nextPath)
         } message: { alertMessageType in
-            Text(alertMessageType.title)
+            Text(alertMessageType.message)
         }
         .onAppear() {
             timerManager.counter = 0

--- a/Balance-Catch-iOS/Balance-Catch-iOS/Custom/Timer/TimerSound.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/Custom/Timer/TimerSound.swift
@@ -1,0 +1,30 @@
+//
+//  TimerSound.swift
+//  Balance-Catch-iOS
+//
+//  Created by 민지은 on 2023/05/28.
+//
+
+import SwiftUI
+import AVFoundation
+
+class Sounds {
+
+   static var audioPlayer:AVAudioPlayer?
+
+   static func playSounds(soundfile: String) {
+
+       if let path = Bundle.main.path(forResource: soundfile, ofType: nil){
+
+           do{
+
+               audioPlayer = try AVAudioPlayer(contentsOf: URL(fileURLWithPath: path))
+               audioPlayer?.prepareToPlay()
+               audioPlayer?.play()
+
+           }catch {
+               print("Error")
+           }
+       }
+    }
+ }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/Model/PlayerModel.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/Model/PlayerModel.swift
@@ -10,6 +10,7 @@ import Foundation
 struct Player: Identifiable {
     let id = UUID()
     var name: String
+    var select: Int
 }
 
 class PlayerList: ObservableObject {
@@ -20,7 +21,7 @@ class PlayerList: ObservableObject {
     }
     
     func addPlayer(name: String) {
-        let player = Player(name: name)
+        let player = Player(name: name,select : -1)
         players.append(player)
     }
     

--- a/Balance-Catch-iOS/Balance-Catch-iOS/Model/UserQuestion.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/Model/UserQuestion.swift
@@ -1,0 +1,16 @@
+//
+//  UserQuestion.swift
+//  Balance-Catch-iOS
+//
+//  Created by 민지은 on 2023/05/26.
+//
+
+import Foundation
+
+class UserQuestion: ObservableObject {
+    @Published var playQuestion: String
+    
+    init(playQuestion: String = ""){
+        self.playQuestion = playQuestion
+    }
+}

--- a/Balance-Catch-iOS/Balance-Catch-iOS/Route/Route.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/Route/Route.swift
@@ -11,7 +11,7 @@ enum Route: Hashable {
     case playerNameInputView(numberOfPeople: Int)
     case selectTypeView
     case selectQuestionView(isRandomPick: Bool)
-    case userFirstSelectView(selectedQuestion: Question)
+    case userFirstSelectView(selectedQuestion: Question,index: Int)
     case timerView
     case firstTeamSpeakingView
     case secondTeamSpeakingView

--- a/Balance-Catch-iOS/Balance-Catch-iOS/Route/Route.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/Route/Route.swift
@@ -15,7 +15,7 @@ enum Route: Hashable {
     case timerView
     case firstTeamSpeakingView
     case secondTeamSpeakingView
-    case userFinalSelectView
+    case userFinalSelectView(questionArray: [String],index: Int)
     case recommandOrNotView
     case publicPickView
     case whoIsLoserView

--- a/Balance-Catch-iOS/Balance-Catch-iOS/Route/Route.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/Route/Route.swift
@@ -13,8 +13,8 @@ enum Route: Hashable {
     case selectQuestionView(isRandomPick: Bool)
     case userFirstSelectView(selectedQuestion: Question,index: Int)
     case timerView
-    case firstTeamSpeakingView
-    case secondTeamSpeakingView
+    case firstTeamSpeakingView(questionArray: [String])
+    case secondTeamSpeakingView(questionArray: [String])
     case userFinalSelectView(questionArray: [String],index: Int)
     case recommandOrNotView
     case publicPickView

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/FirstTeamSpeakingView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/FirstTeamSpeakingView.swift
@@ -40,7 +40,7 @@ struct FirstTeamSpeakingView: View {
                     .stroke(Color("BalanceCatchBlue").opacity(1),lineWidth: 4))
                 .padding(.bottom, 40)
             
-            CircleTimer(timerManager: TimerManager(totalTime: 15),
+            CircleTimer(timerManager: TimerManager(totalTime: 20),
                         nextPath: Route.secondTeamSpeakingView,
                         alertMessageType: .firstTeam,
                         isStartButtonPressed: $isStartButtonPressed)

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/FirstTeamSpeakingView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/FirstTeamSpeakingView.swift
@@ -7,11 +7,27 @@
 
 import SwiftUI
 
+
+
 struct FirstTeamSpeakingView: View {
     @Environment(\.dismiss) private var dismiss
     @Binding var path: [Route]
     @State var isStartButtonPressed = false
     @State var circleTimerId = UUID()
+    @EnvironmentObject var userQuestion: UserQuestion
+    let questionArray: [String]
+    
+    
+    init(questionArray: [String], path: Binding<[Route]>) {
+        self.questionArray = questionArray
+        _path = path
+        
+    }
+    
+    var first: String {
+        questionArray.first ?? ""
+    }
+    
     
     var body: some View{
         
@@ -24,8 +40,8 @@ struct FirstTeamSpeakingView: View {
                 .shadow(color:.gray,radius:2,x:3,y:3)
                 .padding(.bottom, 35)
                 .padding(.top,-10)
-            
-            Text("잠수이별") // 나중에 질문 값 받아와야 함
+
+            Text("\(first)") // 나중에 질문 값 받아와야 함
                 .font(.system(size: 22, weight: .bold))
                 .minimumScaleFactor(0.5)
                 .padding(.bottom, 10)
@@ -41,7 +57,7 @@ struct FirstTeamSpeakingView: View {
                 .padding(.bottom, 40)
             
             CircleTimer(timerManager: TimerManager(totalTime: 20),
-                        nextPath: Route.secondTeamSpeakingView,
+                        nextPath: Route.secondTeamSpeakingView(questionArray: userQuestion.playQuestion.components(separatedBy: " vs ")),
                         alertMessageType: .firstTeam,
                         isStartButtonPressed: $isStartButtonPressed)
             .id(circleTimerId)
@@ -54,7 +70,7 @@ struct FirstTeamSpeakingView: View {
                 }
                 .buttonStyle(RoundedBlueButton())
             } else {
-                NavigationLink("Next", value: Route.secondTeamSpeakingView)
+                NavigationLink("Next", value: Route.secondTeamSpeakingView(questionArray: userQuestion.playQuestion.components(separatedBy: " vs ")))
                     .buttonStyle(RoundedBlueButton())
             }
         }//Vstack
@@ -66,8 +82,8 @@ struct FirstTeamSpeakingView: View {
         Spacer()
         
             .balanceCatchBackButton {
-                       dismiss()
-                   }
+                dismiss()
+            }
         
     }
     
@@ -76,6 +92,6 @@ struct FirstTeamSpeakingView: View {
 
 struct FirstTeamSpeakingView_Previews: PreviewProvider {
     static var previews: some View {
-        FirstTeamSpeakingView(path: Binding.constant([]))
+        FirstTeamSpeakingView(questionArray: [],path: Binding.constant([]))
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/LaunchScreenView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/LaunchScreenView.swift
@@ -46,8 +46,8 @@ struct LaunchScreenView: View {
                 case .selectQuestionView(let isRandomPick):
                     SelectQuestionView(isRandomPick: isRandomPick,
                                        path: $path)
-                case .userFirstSelectView(let selectedQuestion):
-                    UserFirstSelectView(selectedQuestion: selectedQuestion,
+                case .userFirstSelectView(let selectedQuestion,let index):
+                    UserFirstSelectView(selectedQuestion: selectedQuestion, index: index,
                                         path: $path)
                 case .timerView:
                     TimerView(path: $path)

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/LaunchScreenView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/LaunchScreenView.swift
@@ -55,8 +55,8 @@ struct LaunchScreenView: View {
                     FirstTeamSpeakingView(path: $path)
                 case .secondTeamSpeakingView:
                     SecondTeamSpeakingView(path: $path)
-                case .userFinalSelectView:
-                    UserFinalSelectView(path: $path)
+                case .userFinalSelectView(let questionArray,let index):
+                    UserFinalSelectView(questionArray: questionArray, index: index, path: $path)
                 case .recommandOrNotView:
                     RecommandOrNotView(path: $path)
                 case .publicPickView:

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/LaunchScreenView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/LaunchScreenView.swift
@@ -51,10 +51,10 @@ struct LaunchScreenView: View {
                                         path: $path)
                 case .timerView:
                     TimerView(path: $path)
-                case .firstTeamSpeakingView:
-                    FirstTeamSpeakingView(path: $path)
-                case .secondTeamSpeakingView:
-                    SecondTeamSpeakingView(path: $path)
+                case .firstTeamSpeakingView(let questionArray):
+                    FirstTeamSpeakingView(questionArray: questionArray, path: $path)
+                case .secondTeamSpeakingView(let questionArray):
+                    SecondTeamSpeakingView(questionArray: questionArray, path: $path)
                 case .userFinalSelectView(let questionArray,let index):
                     UserFinalSelectView(questionArray: questionArray, index: index, path: $path)
                 case .recommandOrNotView:

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/PlayerNameInputView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/PlayerNameInputView.swift
@@ -42,15 +42,15 @@ struct PlayerNameInputView: View {
                                     .multilineTextAlignment(.leading)
                                     .padding(.horizontal, 30.0)
                                     .padding(.vertical, 30.0)
-                                    /*.background(
-                                        RoundedRectangle(cornerRadius: 20)
-                                            .inset(by: 3)
-                                            .stroke(
-                                                self.playerNames[index].isEmpty ? Color.gray:
-                                                        .balanceCatchBlue,
-                                                lineWidth: 5
-                                            )
-                                    )*/
+                                /*.background(
+                                 RoundedRectangle(cornerRadius: 20)
+                                 .inset(by: 3)
+                                 .stroke(
+                                 self.playerNames[index].isEmpty ? Color.gray:
+                                 .balanceCatchBlue,
+                                 lineWidth: 5
+                                 )
+                                 )*/
                                     .background(Color.white)
                                     .cornerRadius(20)
                                     .shadow(color:.gray,radius:2,x:3,y:3)
@@ -110,8 +110,8 @@ struct PlayerNameInputView: View {
             self.playerNames = Array(repeating: "", count: numberOfPeople)
         }
         .balanceCatchBackButton {
-                   dismiss()
-               }
+            dismiss()
+        }
     }
 }
 

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/SecondTeamSpeakingView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/SecondTeamSpeakingView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SecondTeamSpeakingView: View {
     @Environment(\.dismiss) private var dismiss
     @Binding var path: [Route]
+    @EnvironmentObject var userQuestion: UserQuestion
     
     @State var isStartButtonPressed = false
     @State var circleTimerId = UUID()
@@ -42,8 +43,8 @@ struct SecondTeamSpeakingView: View {
                     .stroke(Color("BalanceCatchBlue").opacity(1),lineWidth: 4))
                 .padding(.bottom, 40)
             
-            CircleTimer(timerManager: TimerManager(totalTime: 15),
-                        nextPath: Route.userFinalSelectView,
+            CircleTimer(timerManager: TimerManager(totalTime: 20),
+                        nextPath: Route.userFinalSelectView(questionArray: userQuestion.playQuestion.components(separatedBy: " vs "),index: 0),
                         alertMessageType: .secondTeam,
                         isStartButtonPressed: $isStartButtonPressed)
             .id(circleTimerId)
@@ -56,7 +57,7 @@ struct SecondTeamSpeakingView: View {
                 }
                 .buttonStyle(RoundedBlueButton())
             } else {
-                NavigationLink("Next", value: Route.userFinalSelectView)
+                NavigationLink("Next", value: Route.userFinalSelectView(questionArray: userQuestion.playQuestion.components(separatedBy: " vs "),index: 0))
                     .buttonStyle(RoundedBlueButton())
             }
         }//Vstack

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/SecondTeamSpeakingView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/SecondTeamSpeakingView.swift
@@ -11,14 +11,26 @@ struct SecondTeamSpeakingView: View {
     @Environment(\.dismiss) private var dismiss
     @Binding var path: [Route]
     @EnvironmentObject var userQuestion: UserQuestion
+    let questionArray: [String]
     
     @State var isStartButtonPressed = false
     @State var circleTimerId = UUID()
     
+    init(questionArray: [String], path: Binding<[Route]>) {
+        self.questionArray = questionArray
+        _path = path
+        
+    }
+    
+    var second: String {
+        questionArray.last ?? ""
+    }
+    
+    
     var body: some View{
         
         Spacer()
-        
+
         VStack{
             Text("최후 변론 TIME")
                 .font(.system(size:36))
@@ -28,7 +40,7 @@ struct SecondTeamSpeakingView: View {
                 .padding(.top,-10)
             
             
-            Text("환승이별") // 나중에 질문 값 받아와야 함
+            Text("\(second)") // 나중에 질문 값 받아와야 함
                 .font(.system(size: 22, weight: .bold))
                 .minimumScaleFactor(0.5)
                 .padding(.bottom, 10)
@@ -77,6 +89,6 @@ struct SecondTeamSpeakingView: View {
 
 struct SecondTeamSpeakingView_Previews: PreviewProvider {
     static var previews: some View {
-        SecondTeamSpeakingView(path: Binding.constant([]))
+        SecondTeamSpeakingView(questionArray: [], path: Binding.constant([]))
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectQuestionView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectQuestionView.swift
@@ -16,6 +16,7 @@ struct SelectQuestionView: View {
     @State var questionViewId = UUID()
     @Binding var path: [Route]
     
+    
     var questions: [Question] = getNewQuestionList()
     
     init(isRandomPick: Bool, selectedIndex: Int = 0, path: Binding<[Route]>) {
@@ -49,6 +50,7 @@ struct SelectQuestionView: View {
                                    value:
                                     Route.userFirstSelectView(selectedQuestion: questions[selectedIndex],index: 0))
                     .buttonStyle(RoundedBlueButton())
+
                 }
             }
         }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectQuestionView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectQuestionView.swift
@@ -47,7 +47,7 @@ struct SelectQuestionView: View {
                 } else {
                     NavigationLink("Next",
                                    value:
-                                    Route.userFirstSelectView(selectedQuestion: questions[selectedIndex]))
+                                    Route.userFirstSelectView(selectedQuestion: questions[selectedIndex],index: 0))
                     .buttonStyle(RoundedBlueButton())
                 }
             }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/TimerView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/TimerView.swift
@@ -10,13 +10,22 @@ import SwiftUI
 struct TimerView: View {
     @Environment(\.dismiss) private var dismiss
     @Binding var path: [Route]
+    @EnvironmentObject var userQuestion: UserQuestion
     
     @State var isStartButtonPressed = false
     @State var circleTimerId = UUID()
+
+    init(path: Binding<[Route]>){
+        questionArray = []
+        _path = path
+    }
+    
+    var questionArray: [String]
     
     var body: some View{
         
         VStack{
+            
             Text("전체 토론 TIME")
                 .font(.system(size:36))
                 .fontWeight(.bold)
@@ -24,7 +33,7 @@ struct TimerView: View {
                 .padding(.bottom, 45)
             
             CircleTimer(timerManager: TimerManager(totalTime: 180),
-                        nextPath: Route.firstTeamSpeakingView,
+                        nextPath: Route.firstTeamSpeakingView(questionArray: questionArray),
                         alertMessageType: .whole,
                         isStartButtonPressed: $isStartButtonPressed)
             .id(circleTimerId)
@@ -37,7 +46,7 @@ struct TimerView: View {
                 }
                 .buttonStyle(RoundedBlueButton())
             } else {
-                NavigationLink("Next", value: Route.firstTeamSpeakingView)
+                NavigationLink("Next", value: Route.firstTeamSpeakingView(questionArray: userQuestion.playQuestion.components(separatedBy: " vs ")))
                     .buttonStyle(RoundedBlueButton())
             }
         }//Vstack

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/TimerView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/TimerView.swift
@@ -32,7 +32,7 @@ struct TimerView: View {
                 .shadow(color:.gray,radius:2,x:3,y:3)
                 .padding(.bottom, 45)
             
-            CircleTimer(timerManager: TimerManager(totalTime: 3),
+            CircleTimer(timerManager: TimerManager(totalTime: 180),
                         nextPath: Route.firstTeamSpeakingView(questionArray: userQuestion.playQuestion.components(separatedBy: " vs ")),
                         alertMessageType: .whole,
                         isStartButtonPressed: $isStartButtonPressed)

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/TimerView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/TimerView.swift
@@ -32,8 +32,8 @@ struct TimerView: View {
                 .shadow(color:.gray,radius:2,x:3,y:3)
                 .padding(.bottom, 45)
             
-            CircleTimer(timerManager: TimerManager(totalTime: 180),
-                        nextPath: Route.firstTeamSpeakingView(questionArray: questionArray),
+            CircleTimer(timerManager: TimerManager(totalTime: 3),
+                        nextPath: Route.firstTeamSpeakingView(questionArray: userQuestion.playQuestion.components(separatedBy: " vs ")),
                         alertMessageType: .whole,
                         isStartButtonPressed: $isStartButtonPressed)
             .id(circleTimerId)

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/TimerView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/TimerView.swift
@@ -23,7 +23,7 @@ struct TimerView: View {
                 .shadow(color:.gray,radius:2,x:3,y:3)
                 .padding(.bottom, 45)
             
-            CircleTimer(timerManager: TimerManager(totalTime: 25),
+            CircleTimer(timerManager: TimerManager(totalTime: 180),
                         nextPath: Route.firstTeamSpeakingView,
                         alertMessageType: .whole,
                         isStartButtonPressed: $isStartButtonPressed)

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFinalSelectView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFinalSelectView.swift
@@ -9,11 +9,14 @@ import SwiftUI
 
 struct UserFinalSelectView: View {
     @Environment(\.dismiss) private var dismiss
+    // MARK: - Player 데이터 가져오기
+    @EnvironmentObject var playerList: PlayerList
     @Binding var path: [Route]
     
     @State private var isActivated1: Bool = false
     @State private var isActivated2: Bool = false
     @State var showingSubview = false
+    @State var index = 0
     
     var body: some View {
         VStack{
@@ -25,12 +28,13 @@ struct UserFinalSelectView: View {
             
             // Player 1 제리
             HStack{
-                Text("Player 1")
+                Text("Player \(index + 1) \(playerList.players[index].select)")
+                Text("Player \(index + 1)")
                     .font(.system(size:24))
                     .fontWeight(.bold)
                     .shadow(color:.gray,radius:2,x:3,y:3)
                 
-                Text("제리")
+                Text(playerList.players[index].name)
                     .font(.system(size:20))
                     .fontWeight(.bold)
                     .frame(width: 150, height: 56)
@@ -48,13 +52,11 @@ struct UserFinalSelectView: View {
                 
                 VStack{
                     Button(action: {
-                        if(isActivated2==true){
-                            self.isActivated1.toggle()
+                        if isActivated2 {
                             self.isActivated2 = false
                         }
-                        else{
-                            self.isActivated1.toggle()
-                        }
+                        self.isActivated1.toggle()
+                        playerList.players[index].select = 0
                     })
                     {
                         Text("받아온 질문")
@@ -76,8 +78,8 @@ struct UserFinalSelectView: View {
                         if isActivated1 {
                             self.isActivated1 = false
                         }
-                        
                         self.isActivated2.toggle()
+                        playerList.players[index].select = 1
                     }) {
                         Text("받아온 질문")
                             .font(.system(size: 27, weight: .bold))
@@ -99,27 +101,39 @@ struct UserFinalSelectView: View {
                     .font(.system(size: 64, weight: .black))
                     .shadow(color:.gray,radius:2, x: 1, y:1)
                     .padding(.bottom, 25)
+                
+                
+            }
+            .task {
+                withAnimation(.easeInOut(duration: 1)) {
+                    showingSubview = true
+                }
             }
             
-
-            NavigationLink("Next", value: Route.recommandOrNotView)
+            if index < playerList.players.count - 1 {
+                Button("Next") {
+                    self.index += 1
+                    isActivated1 = false
+                    isActivated2 = false
+                }
                 .buttonStyle(RoundedBlueButton())
                 .disabled(!isActivated1 && !isActivated2)
-
-        }
-        .task {
-            withAnimation(.easeInOut(duration: 1)) {
-                showingSubview = true
+            } else {
+                NavigationLink("Next", value: Route.recommandOrNotView)
+                    .buttonStyle(RoundedBlueButton())
+                    .disabled(!isActivated1 && !isActivated2)
             }
         }
+        
         .padding(.top,100)
         .padding(.bottom,100) //임시값
         
         .balanceCatchBackButton {
-                   dismiss()
-               }
+            dismiss()
+        }
     }
 }
+
 
 struct UserFinalSelect_Previews: PreviewProvider {
     static var previews: some View {

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFinalSelectView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFinalSelectView.swift
@@ -9,14 +9,32 @@ import SwiftUI
 
 struct UserFinalSelectView: View {
     @Environment(\.dismiss) private var dismiss
-    // MARK: - Player 데이터 가져오기
+
     @EnvironmentObject var playerList: PlayerList
+    @EnvironmentObject var userQuestion: UserQuestion
+    let questionArray: [String]
+    let index: Int
+    
     @Binding var path: [Route]
     
     @State private var isActivated1: Bool = false
     @State private var isActivated2: Bool = false
     @State var showingSubview = false
-    @State var index = 0
+    
+    
+    init(questionArray: [String], index: Int, path: Binding<[Route]>) {
+        self.questionArray = questionArray
+        self.index = index
+        _path = path
+        
+    }
+
+    var first: String {
+        questionArray.first ?? ""
+    }
+    var second: String {
+        questionArray.last ?? ""
+    }
     
     var body: some View {
         VStack{
@@ -26,8 +44,8 @@ struct UserFinalSelectView: View {
                 .shadow(color:.gray,radius:2,x:3,y:3)
                 .padding(.bottom, 51)
             
-            // Player 1 제리
             HStack{
+                // 선택지 왼쪽일 때 0, 오른쪽일 때 1 확인용
                 Text("Player \(index + 1) \(playerList.players[index].select)")
                 Text("Player \(index + 1)")
                     .font(.system(size:24))
@@ -59,7 +77,7 @@ struct UserFinalSelectView: View {
                         playerList.players[index].select = 0
                     })
                     {
-                        Text("받아온 질문")
+                        Text("\(first)")
                             .font(.system(size: 27, weight: .bold))
                             .minimumScaleFactor(0.5)
                             .padding(.leading, 30)
@@ -81,7 +99,7 @@ struct UserFinalSelectView: View {
                         self.isActivated2.toggle()
                         playerList.players[index].select = 1
                     }) {
-                        Text("받아온 질문")
+                        Text("\(second)")
                             .font(.system(size: 27, weight: .bold))
                             .minimumScaleFactor(0.5)
                             .padding(.trailing, 30)
@@ -109,15 +127,11 @@ struct UserFinalSelectView: View {
                     showingSubview = true
                 }
             }
-            
+          
             if index < playerList.players.count - 1 {
-                Button("Next") {
-                    self.index += 1
-                    isActivated1 = false
-                    isActivated2 = false
-                }
-                .buttonStyle(RoundedBlueButton())
-                .disabled(!isActivated1 && !isActivated2)
+                NavigationLink("Next", value: Route.userFinalSelectView(questionArray: userQuestion.playQuestion.components(separatedBy: " vs "),index: index + 1))
+                    .buttonStyle(RoundedBlueButton())
+                    .disabled(!isActivated1 && !isActivated2)
             } else {
                 NavigationLink("Next", value: Route.recommandOrNotView)
                     .buttonStyle(RoundedBlueButton())
@@ -131,12 +145,16 @@ struct UserFinalSelectView: View {
         .balanceCatchBackButton {
             dismiss()
         }
+        
     }
 }
 
 
+
+
 struct UserFinalSelect_Previews: PreviewProvider {
     static var previews: some View {
-        UserFinalSelectView(path: Binding.constant([]))
+        UserFinalSelectView(questionArray: [],index: 0, path: Binding.constant([]))
+        
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFirstSelectView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFirstSelectView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 import Foundation
 
+
+
 struct UserFirstSelectView: View {
     @Environment(\.dismiss) private var dismiss
 
@@ -22,7 +24,6 @@ struct UserFirstSelectView: View {
     @State private var isActivated2: Bool = false
     @State var showingSubview = false
     
-    
     init(selectedQuestion: Question, index: Int, path: Binding<[Route]>) {
         self.selectedQuestion = selectedQuestion
         self.index = index
@@ -31,17 +32,14 @@ struct UserFirstSelectView: View {
     }
     
     var questionArray: [String]
-    
-    mutating func onAppear() {
-        questionArray = selectedQuestion.text.components(separatedBy: " vs ")
-    }
-    
+
     var first: String {
         questionArray.first ?? ""
     }
     var second: String {
         questionArray.last ?? ""
     }
+    
 
     
     
@@ -61,11 +59,11 @@ struct UserFirstSelectView: View {
             HStack{
                 // 선택지 왼쪽일 때 0, 오른쪽일 때 1 확인용
                 Text("Player \(index + 1) \(playerList.players[index].select)")
+               
                 Text("Player \(index + 1)")
                     .font(.system(size:24))
                     .fontWeight(.bold)
                     .shadow(color:.gray,radius:2,x:3,y:3)
-                
                 Text(playerList.players[index].name)
                     .font(.system(size:20))
                     .fontWeight(.bold)
@@ -76,9 +74,10 @@ struct UserFirstSelectView: View {
                     .overlay(RoundedRectangle(cornerRadius: 20)
                         .stroke(Color("BalanceCatchBlue").opacity(1),lineWidth: 4))
                     .padding(.leading, 24)
+            
                 
             }.padding(.bottom, 40) //HStack
-            
+
             ZStack{
                 
                 VStack{
@@ -152,6 +151,8 @@ struct UserFirstSelectView: View {
                 NavigationLink("Next", value: Route.userFirstSelectView(selectedQuestion: self.selectedQuestion,index: index + 1))
                     .buttonStyle(RoundedBlueButton())
                     .disabled(!isActivated1 && !isActivated2)
+                    .simultaneousGesture(TapGesture().onEnded{
+                     })
             } else {
                 NavigationLink("Next", value: Route.timerView)
                     .buttonStyle(RoundedBlueButton())
@@ -163,7 +164,7 @@ struct UserFirstSelectView: View {
         .padding(.top,100)
         .padding(.bottom,100) //임시값
         .onAppear {
-            self.userQuestion.playQuestion += selectedQuestion.text
+            self.userQuestion.playQuestion = selectedQuestion.text
         }
         .balanceCatchBackButton {
             dismiss()

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFirstSelectView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFirstSelectView.swift
@@ -10,15 +10,18 @@ import Foundation
 
 struct UserFirstSelectView: View {
     @Environment(\.dismiss) private var dismiss
-    // MARK: - Player 데이터 가져오기
+
     @EnvironmentObject var playerList: PlayerList
+    @EnvironmentObject var userQuestion: UserQuestion
     let selectedQuestion: Question
     let index: Int
-    @Binding var path: [Route]
     
+    
+    @Binding var path: [Route]
     @State private var isActivated1: Bool = false
     @State private var isActivated2: Bool = false
     @State var showingSubview = false
+    
     
     init(selectedQuestion: Question, index: Int, path: Binding<[Route]>) {
         self.selectedQuestion = selectedQuestion
@@ -26,7 +29,6 @@ struct UserFirstSelectView: View {
         questionArray = selectedQuestion.text.components(separatedBy: " vs ")
         _path = path
     }
-
     
     var questionArray: [String]
     
@@ -40,8 +42,15 @@ struct UserFirstSelectView: View {
     var second: String {
         questionArray.last ?? ""
     }
+
+    
+    
+    
     
     var body: some View {
+        
+        
+        
         VStack{
             Text("1차 선택")
                 .font(.system(size:24))
@@ -49,9 +58,8 @@ struct UserFirstSelectView: View {
                 .shadow(color:.gray,radius:2,x:3,y:3)
                 .padding(.bottom, 51)
             
-            // MARK: - Player 데이터 가져오기
-            
             HStack{
+                // 선택지 왼쪽일 때 0, 오른쪽일 때 1 확인용
                 Text("Player \(index + 1) \(playerList.players[index].select)")
                 Text("Player \(index + 1)")
                     .font(.system(size:24))
@@ -80,6 +88,7 @@ struct UserFirstSelectView: View {
                         }
                         self.isActivated1.toggle()
                         playerList.players[index].select = 0
+
                     })
                     {
                         Text("\(first)")
@@ -151,9 +160,11 @@ struct UserFirstSelectView: View {
             
             
         }
-        
         .padding(.top,100)
         .padding(.bottom,100) //임시값
+        .onAppear {
+            self.userQuestion.playQuestion += selectedQuestion.text
+        }
         .balanceCatchBackButton {
             dismiss()
         }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFirstSelectView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFirstSelectView.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct UserFirstSelectView: View {
     @Environment(\.dismiss) private var dismiss
-// MARK: - Player 데이터 가져오기
+    // MARK: - Player 데이터 가져오기
     @EnvironmentObject var playerList: PlayerList
     let selectedQuestion: Question
     @Binding var path: [Route]
@@ -20,7 +20,7 @@ struct UserFirstSelectView: View {
     @State var showingSubview = false
     
     init(selectedQuestion: Question, path: Binding<[Route]>) {
-
+        
         self.selectedQuestion = selectedQuestion
         questionArray = selectedQuestion.text.components(separatedBy: " vs ")
         _path = path
@@ -38,7 +38,7 @@ struct UserFirstSelectView: View {
     var second: String {
         questionArray.last ?? ""
     }
-    
+    @State var index = 0
     var body: some View {
         VStack{
             Text("1차 선택")
@@ -47,21 +47,16 @@ struct UserFirstSelectView: View {
                 .shadow(color:.gray,radius:2,x:3,y:3)
                 .padding(.bottom, 51)
             
-            // Player 1 제리
+            // MARK: - Player 데이터 가져오기
             
-// MARK: - Player 데이터 가져오기
-            VStack {
-                ForEach(playerList.players, id: \.id) { player in
-                    Text(player.name)
-                }
-            }
             HStack{
-                Text("Player 1")
+                //Text("Player \(index + 1) \(playerList.players[index].select)") 확인용
+                Text("Player \(index + 1)")
                     .font(.system(size:24))
                     .fontWeight(.bold)
                     .shadow(color:.gray,radius:2,x:3,y:3)
                 
-                Text("제리")
+                Text(playerList.players[index].name)
                     .font(.system(size:20))
                     .fontWeight(.bold)
                     .frame(width: 150, height: 56)
@@ -72,21 +67,17 @@ struct UserFirstSelectView: View {
                         .stroke(Color("BalanceCatchBlue").opacity(1),lineWidth: 4))
                     .padding(.leading, 24)
                 
-            }.padding(.bottom, 40)
-            
-            
+            }.padding(.bottom, 40) //HStack
             
             ZStack{
                 
                 VStack{
                     Button(action: {
-                        if(isActivated2==true){
-                            self.isActivated1.toggle()
+                        if isActivated2 {
                             self.isActivated2 = false
                         }
-                        else{
-                            self.isActivated1.toggle()
-                        }
+                        self.isActivated1.toggle()
+                        playerList.players[index].select = 0
                     })
                     {
                         Text("\(first)")
@@ -111,6 +102,7 @@ struct UserFirstSelectView: View {
                             self.isActivated1 = false
                         }
                         self.isActivated2.toggle()
+                        playerList.players[index].select = 1
                     }) {
                         Text("\(second)")
                             .font(.system(size: 27, weight: .bold))
@@ -139,26 +131,35 @@ struct UserFirstSelectView: View {
                 
                 
             }
+            .task {
+                withAnimation(.easeInOut(duration: 1)) {
+                    showingSubview = true
+                }
+            }
             
-            NavigationLink("Next", value: Route.timerView)
+            if index < playerList.players.count - 1 {
+                Button("Next") {
+                    self.index += 1
+                    isActivated1 = false
+                    isActivated2 = false
+                }
                 .buttonStyle(RoundedBlueButton())
                 .disabled(!isActivated1 && !isActivated2)
-            
-        
-        }
-        .task {
-            withAnimation(.easeInOut(duration: 1)) {
-                showingSubview = true
+            } else {
+                NavigationLink("Next", value: Route.timerView)
+                    .buttonStyle(RoundedBlueButton())
+                    .disabled(!isActivated1 && !isActivated2)
             }
+            
+            
         }
         
         .padding(.top,100)
         .padding(.bottom,100) //임시값
         .balanceCatchBackButton {
-                   dismiss()
-               }
+            dismiss()
+        }
     }
-    
 }
 
 

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFirstSelectView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/UserFirstSelectView.swift
@@ -13,18 +13,20 @@ struct UserFirstSelectView: View {
     // MARK: - Player 데이터 가져오기
     @EnvironmentObject var playerList: PlayerList
     let selectedQuestion: Question
+    let index: Int
     @Binding var path: [Route]
     
     @State private var isActivated1: Bool = false
     @State private var isActivated2: Bool = false
     @State var showingSubview = false
     
-    init(selectedQuestion: Question, path: Binding<[Route]>) {
-        
+    init(selectedQuestion: Question, index: Int, path: Binding<[Route]>) {
         self.selectedQuestion = selectedQuestion
+        self.index = index
         questionArray = selectedQuestion.text.components(separatedBy: " vs ")
         _path = path
     }
+
     
     var questionArray: [String]
     
@@ -38,7 +40,7 @@ struct UserFirstSelectView: View {
     var second: String {
         questionArray.last ?? ""
     }
-    @State var index = 0
+    
     var body: some View {
         VStack{
             Text("1차 선택")
@@ -50,7 +52,7 @@ struct UserFirstSelectView: View {
             // MARK: - Player 데이터 가져오기
             
             HStack{
-                //Text("Player \(index + 1) \(playerList.players[index].select)") 확인용
+                Text("Player \(index + 1) \(playerList.players[index].select)")
                 Text("Player \(index + 1)")
                     .font(.system(size:24))
                     .fontWeight(.bold)
@@ -138,13 +140,9 @@ struct UserFirstSelectView: View {
             }
             
             if index < playerList.players.count - 1 {
-                Button("Next") {
-                    self.index += 1
-                    isActivated1 = false
-                    isActivated2 = false
-                }
-                .buttonStyle(RoundedBlueButton())
-                .disabled(!isActivated1 && !isActivated2)
+                NavigationLink("Next", value: Route.userFirstSelectView(selectedQuestion: self.selectedQuestion,index: index + 1))
+                    .buttonStyle(RoundedBlueButton())
+                    .disabled(!isActivated1 && !isActivated2)
             } else {
                 NavigationLink("Next", value: Route.timerView)
                     .buttonStyle(RoundedBlueButton())
@@ -166,6 +164,6 @@ struct UserFirstSelectView: View {
 
 struct UserFirstSelect_Previews: PreviewProvider {
     static var previews: some View {
-        UserFirstSelectView(selectedQuestion: .init(text: "test"), path: Binding.constant([]))
+        UserFirstSelectView(selectedQuestion: .init(text: "test"), index: 0, path: Binding.constant([]))
     }
 }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/WhoIsLoserView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/WhoIsLoserView.swift
@@ -61,10 +61,21 @@ struct WhoIsLoserView: View {
             .padding(.bottom,56)
             
             HStack{
-                Button("New Game") {
+                Button("Plus Person gogo") {
                     moveToPlayerNumberInputView()
                 }
-                .buttonStyle(BiggerRoundedBlueButton())
+                .frame(width: 220,
+                       height: 56,
+                       alignment: .center)
+                .font(.system(size: 20, weight: .bold))
+                .foregroundColor(.white)
+                .background(.balanceCatchBlue)
+                .cornerRadius(25)
+                .shadow(color: .black.opacity(0.25),
+                        radius: 2,
+                        x: 0,
+                        y: 4)
+
                 Button("Replay") {
                     moveToSelectTypeView()
                 }


### PR DESCRIPTION
## Motivation ⍰

- 입력받은 플레이어의 수만큼 화면 제공 X
- userFinalSelectView에서 선택된 질문 모름
- 플레이어가 선택한 질문의 정보를 저장 기능 필요
- 팀별 최후변론에서 질문 받아오는 기능 필요
<br>

## Key Changes 🔑

- EnvironmentObject를 사용하여 선택된 질문을 가져올 수 있게 수정
- index가 플레이어 수를 충족할 때까지 플레이어별 선택지 view 제공
- 타이머 시간 상세 설정
- 팀별 토론화면에 questionArray 값을 넘겨줘서 질문을 가져옴
- alert창 타이틀과 내용이 같은 점 수정
- new game -> plus person gogo 로 수정

<br>

## To Reviewers 🙏🏻

- [x] 플레이어 수만큼 선택지 view가 잘 생성되는지 확인해주세요
- [x] 플레이어가 넘어갈 때마다 애니메이션이 잘 적용되는지 확인해주세요
- [x] 플레이어가 선택한 왼쪽(0) 오른쪽(1)의 값이 first -> final 까지 잘 유지되는지 확인해주세요
- [x] 선택된 질문이 first와 final 2개의 view에서 모두 다 잘 나오는지 확인해주세요
- [x] 팀별 토론화면에 선택한 질문이 잘 나오는지 확인해주세요 (alert를 이용해서 넘어갈 때)
- [x] 팀별 토론화면에 선택한 질문이 잘 나오는지 확인해주세요 (next를 이용해서 넘어갈 때)
- [x] 팀별 토론화면에 선택한 질문이 잘 나오는지 확인해주세요 (replay 후 새로운 질문을 선택했을 때 업데이트가 되는지)


<br>

## Linked Issue 🔗

- 
