### PR TITLE
[#48]Feat: 대중 픽나오는 화면에서 뒤로가기 버튼 히든

### DIFF
--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/PublicPickView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/PublicPickView.swift
@@ -7,7 +7,6 @@
 import SwiftUI
 
 struct PublicPickView: View {
-    @Environment(\.dismiss) private var dismiss
     @State private var animationAmount:CGFloat = 1
     @State private var firstIncreAmount: Double = 0.0
     @State private var secondIncreAmount: Double = 0.0
@@ -121,9 +120,7 @@ struct PublicPickView: View {
                     .buttonStyle(RoundedBlueButton())
             }
         }
-        .balanceCatchBackButton {
-            dismiss()
-        }
+        .navigationBarBackButtonHidden()
     }
 }
 

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/WhoIsLoserView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/WhoIsLoserView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct WhoIsLoserView: View {
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var questionDataViewModel: QuestionDataViewModel
     @Binding var path: [Route]
     
     var body: some View {
@@ -86,7 +87,8 @@ struct WhoIsLoserView: View {
     private func moveToPlayerNumberInputView() {
         for route in path.reversed() {
             if route == .playerNumberInputView {
-                return
+                questionDataViewModel.isAlreadyFetch.value = false
+                break
             } else { path.removeLast() }
         }
     }
@@ -94,7 +96,8 @@ struct WhoIsLoserView: View {
     private func moveToSelectTypeView() {
         for route in path.reversed() {
             if route == .selectTypeView {
-                return
+                questionDataViewModel.isAlreadyFetch.value = false
+                break
             } else { path.removeLast() }
         }
     }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/ViewModel/QuestionDataViewModel.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/ViewModel/QuestionDataViewModel.swift
@@ -29,8 +29,6 @@ final class QuestionDataViewModel: ObservableObject {
                     self.isLoading.send(false)
                 }
             } receiveValue: { data in
-                print("data - \(data)")
-                
                 let data = data.compactMap { questionDataResponseModel in
                     QuestionDataModel(response: questionDataResponseModel)
                 }
@@ -59,7 +57,6 @@ final class QuestionDataViewModel: ObservableObject {
                 self.isLoading.send(false)
             }
         } receiveValue: { data in
-            print("data - \(data)")
             self.isLoading.send(false)
         }
         .cancel(with: cancelBag)


### PR DESCRIPTION
## Motivation ⍰

- 중복 좋아요를 막기 위함
- 마지막 화면에서 new game 혹은 home 클릭 시, 질문 데이터(이전 게임에서 변경된 수치를 반영한 데이터) 재요청
- 필요없는 print 삭제

<br>

## Key Changes 🔑

- 마지막 화면에서 QuestionDataViewModel의 isAlreadyFetch의 값을 false로 수정해서 즉각적으로 질문 데이터를 다시 요청하도록 구현
<img src="https://github.com/Dream-Catch/Balance-Catch-iOS/assets/68800789/48b0f52d-821d-4c69-84c3-27f154484c16" width=60%>

- 대중 픽 결과 화면에서 백 버튼 히든
<img src="https://github.com/Dream-Catch/Balance-Catch-iOS/assets/68800789/c7a3ab57-4842-4817-8287-cfffa759b5c5" width=25%>


<br>

## To Reviewers 🙏🏻

- [x] PublicPickView 뷰에서 백버튼이 없어졌는지 확인해주세요
- [x] 마지막 화면에서 Home 또는 New Game 버튼 클릭 시, 질문 데이터를 재요청하는 지 확인해주세요

<br>

## Linked Issue 🔗

- [x] #48 
