### PR TITLE
[#48]Enhancement:  게임을 재시작 후, 질문 데이터 호출 함수를 중복으로 호출하지 않도록 수정

### DIFF
--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/RecommandOrNotView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/RecommandOrNotView.swift
@@ -57,7 +57,7 @@ struct RecommandOrNotView: View {
                 }
             }
             
-            if isLoading { LoadingView() }
+            if questionDataViewModel.isLoading { LoadingView() }
             else { EmptyView() }
         }
         .onAppear() {
@@ -71,16 +71,6 @@ struct RecommandOrNotView: View {
         .balanceCatchBackButton {
             dismiss()
         }
-    }
-    
-    private func bindCombine() {
-        questionDataViewModel.isLoading
-            .receive(on: DispatchQueue.main)
-            .sink { value in
-                if value { self.isLoading = true }
-                else { self.isLoading = false }
-            }
-            .cancel(with: cancelBag)
     }
 }
 

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectTypeView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectTypeView.swift
@@ -9,14 +9,13 @@ import SwiftUI
 
 struct SelectTypeView: View {
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject var questionDataViewModel: QuestionDataViewModel
     @EnvironmentObject var playerList: PlayerList
+    @EnvironmentObject var questionDataViewModel: QuestionDataViewModel
     
     @Binding var path: [Route]
     
     @State private var isActivated1: Bool = false
     @State private var isActivated2: Bool = false
-    @State private var isLoading: Bool = false
     var cancelBag = CancelBag()
     
     var body: some View {
@@ -64,35 +63,19 @@ struct SelectTypeView: View {
                 .disabled(!isActivated1 && !isActivated2)
             } //Vstack
             .onAppear() {
-                bindCombine()
+                fetchData()
             }
             .balanceCatchBackButton {
                 dismiss()
             }
             
-            if isLoading { LoadingView() }
+            if questionDataViewModel.isLoading { LoadingView() }
             else { EmptyView() }
         }
     } //body
     
-    private func bindCombine() {
-        questionDataViewModel.isAlreadyFetch
-            .receive(on: DispatchQueue.main)
-            .sink { value in
-                if !value {
-                    questionDataViewModel.getQuestionMetaData()
-                    questionDataViewModel.isAlreadyFetch.value = true
-                }
-            }
-            .cancel(with: cancelBag)
-        
-        questionDataViewModel.isLoading
-            .receive(on: DispatchQueue.main)
-            .sink { value in
-                if value { self.isLoading = true }
-                else { self.isLoading = false }
-            }
-            .cancel(with: cancelBag)
+    private func fetchData() {
+        questionDataViewModel.getQuestionMetaData()
     }
 }
 

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/WhoIsLoserView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/WhoIsLoserView.swift
@@ -87,7 +87,6 @@ struct WhoIsLoserView: View {
     private func moveToPlayerNumberInputView() {
         for route in path.reversed() {
             if route == .playerNumberInputView {
-                questionDataViewModel.isAlreadyFetch.value = false
                 break
             } else { path.removeLast() }
         }
@@ -96,7 +95,6 @@ struct WhoIsLoserView: View {
     private func moveToSelectTypeView() {
         for route in path.reversed() {
             if route == .selectTypeView {
-                questionDataViewModel.isAlreadyFetch.value = false
                 break
             } else { path.removeLast() }
         }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/ViewModel/QuestionDataViewModel.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/ViewModel/QuestionDataViewModel.swift
@@ -10,14 +10,13 @@ import Combine
 
 final class QuestionDataViewModel: ObservableObject {
     
-    var isAlreadyFetch = CurrentValueSubject<Bool, Never>(false)
-    var isLoading = PassthroughSubject<Bool, Never>()
+    @Published var isLoading = false
     var questionDataList = CurrentValueSubject<[QuestionDataModel], Never>([])
     var selectedQuestionData: QuestionDataModel? = nil
     var cancelBag = CancelBag()
     
     func getQuestionMetaData() {
-        isLoading.send(true)
+        isLoading = true
         NetworkManager.shared.getQuestionMetaData()
             .receive(on: DispatchQueue.main)
             .sink { result in
@@ -26,14 +25,14 @@ final class QuestionDataViewModel: ObservableObject {
                     print("데이터 응답 성공!")
                 case .failure(let error):
                     print("error - \(error.localizedDescription)")
-                    self.isLoading.send(false)
+                    self.isLoading = false
                 }
             } receiveValue: { data in
                 let data = data.compactMap { questionDataResponseModel in
                     QuestionDataModel(response: questionDataResponseModel)
                 }
                 self.questionDataList.send(data)
-                self.isLoading.send(false)
+                self.isLoading = false
             }
             .cancel(with: cancelBag)
     }
@@ -41,7 +40,7 @@ final class QuestionDataViewModel: ObservableObject {
     func putQuestionLike() {
         guard let selectedQuestionData = selectedQuestionData else { return }
         
-        isLoading.send(true)
+        isLoading = true
         NetworkManager.shared.putQuestionLike(id: selectedQuestionData.id,
                                               good: selectedQuestionData.good,
                                               bad: selectedQuestionData.bad,
@@ -54,10 +53,10 @@ final class QuestionDataViewModel: ObservableObject {
                 print("수정 성공!")
             case .failure(let error):
                 print("error - \(error)")
-                self.isLoading.send(false)
+                self.isLoading = false
             }
         } receiveValue: { data in
-            self.isLoading.send(false)
+            self.isLoading = false
         }
         .cancel(with: cancelBag)
     }


### PR DESCRIPTION
## Motivation ⍰

- SelectTypeView가 띄워질 때마다 호출하는 방식으로 변경

<br>

## Key Changes 🔑

- 기존에는 CurrentValueSubject, PassthroughSubject 타입의 변수로 생성해서 구독하는 방식으로 구현했었습니다. 그런데 ViewModel을 EnvironmenObject(글로벌 변수)로 사용하다보니 게임을 재시작할 때, **구독이 중복으로 되서 네트워크 호출 함수를 여러 번 호출하는 문제**가 발생했습니다.
그 원인은 SelectTypeView에서 bindingCombine() 함수를 여러 번 호출하게 되면 여러 구독자들이 생기기 때문.
값을 불러오는 것은 해당 화면에 진입할 때마다 호출하고, Loading뷰는 따로 구독하는 함수를 만들지 않고 직접 사용하기 위해서 **@Published 타입의 변수**를 만들어서 구현했습니다.

<br>

## To Reviewers 🙏🏻

- [x] SelectTypeView에 진입할 때마다 질문 데이터를 받는 지 확인해주세요
- [x] 게임을 재시작 해서 반복해도 질문 데이터를 한 번만 호출하는 지 확인해주세요

<br>

## Linked Issue 🔗

- [x] #48 
