### PR TITLE
[#64]Enhance: 광고가 안 나왔을 때도 대중 픽 뷰에서 애니메이션 적용

### DIFF
--- a/Balance-Catch-iOS/Balance-Catch-iOS/Custom/PublicPickScoreView/ScoreView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/Custom/PublicPickScoreView/ScoreView.swift
@@ -55,10 +55,9 @@ enum GameResult: String {
 struct ScoreView: View {
     @State var title: String
     @State var percent: Double
-    @State var scale: Double
     @State var gameResult: GameResult
     @State var fromPercent: Double = 0.0
-    @State var fromScale: Double = 1.0
+    @State var scale: Double = 1.0
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -96,7 +95,7 @@ struct ScoreView: View {
         .overlay(StrokeText(text: gameResult.rawValue,
                             width: 2,
                             color: gameResult.color).position(x: 38, y: 0).font(.system(size: 29, weight: .bold)))
-        .scaleEffect(gameResult == .draw ? 1 : fromScale)
+        .scaleEffect(scale)
         .animation(.easeIn(duration: 1).delay(0.2), value: fromPercent)
         .padding(20)
         .onAppear() {
@@ -106,7 +105,7 @@ struct ScoreView: View {
     
     private func updateData() {
         withAnimation {
-            if gameResult == .win { fromScale = scale }
+            if gameResult == .win { scale = 1.2 }
             fromPercent = percent
         }
     }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/PlayerNumberInputView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/PlayerNumberInputView.swift
@@ -16,7 +16,7 @@ struct PlayerNumberInputView: View {
     var body: some View {
         ZStack {
             VStack{
-                Text("인원을 입력해주세요.")
+                Text("인원을 입력해주세요")
                     .font(Font.custom("Arial", size: 24))
                     .fontWeight(.bold)
                     .shadow(color:.gray,radius:2,x:3,y:3)

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/PublicPickView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/PublicPickView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct QuestionData {
     var title: String
     var percent: Double
-    var scale: Double
     var gameResult: GameResult
 }
 
@@ -22,11 +21,9 @@ struct PublicPickView: View {
     @State private var loserSelectType: SelectType = .none
     @State private var winner = QuestionData(title: "",
                                              percent: 50,
-                                             scale: 1.0,
                                              gameResult: .draw)
     @State private var loser = QuestionData(title: "",
                                             percent: 50,
-                                            scale: 1.0,
                                             gameResult: .draw)
     @State private var winViewId = UUID()
     @State private var loseViewId = UUID()
@@ -42,14 +39,12 @@ struct PublicPickView: View {
             
             ScoreView(title: winner.title,
                       percent: winner.percent,
-                      scale: winner.scale,
                       gameResult: winner.gameResult)
             .id(winViewId)
             
             
             ScoreView(title: loser.title,
                       percent: loser.percent,
-                      scale: loser.scale,
                       gameResult: loser.gameResult)
             .id(loseViewId)
             
@@ -66,7 +61,6 @@ struct PublicPickView: View {
         }
         .onReceive(interstitialAd.$isDismiss) { value in
             if value {
-                winner.scale = 1.2
                 winViewId = UUID()
                 loseViewId = UUID()
             }


### PR DESCRIPTION
## Motivation ⍰

- 광고가 안 나왔을 때는 뷰의 스케일이 1.0 -> 1.2
- 광고가 나온 상태면 이미 애니메이션이 적용된 상태인 1.2에서
- 1.2 -> 1 -> 1.2로 애니메이션이 적용됨
- "인원을 입력해주세요"의 온점 삭제

<br>

## Key Changes 🔑

- 기존에는 ScoreView의 스케일을 1.0으로 초기화 한 상태에서 광고가 사라 졌을 때 1.2로 바꿔서 애니메이션을 적용했었음. 그런데 광고가 안 나오는 경우, 애니메이션이 적용되지 않아서 ScoreView의 id가 갱신될 때, 승자의 스케일은 항상 1.2로 할당되도록 수정

기존 코드
```swift
struct ScoreView: View {
    @State var scale: Double = 1.0
    @State var fromScale: Double = 1.0
    
    var body: some View {
        VStack(alignment: .leading) {
            { ... }   
        }
        .scaleEffect(gameResult == .draw ? 1 : fromScale)
        .animation(.easeIn(duration: 1).delay(0.2), value: fromPercent)
        .padding(20)
        .onAppear() {
            updateData()
        }
    }
    
    private func updateData() {
        // 파라미터 값으로 수정하고, 광고가 나오지 않을 때는 1.0이었음.
        withAnimation {
            if gameResult == .win { fromScale = scale }
            fromPercent = percent
        }
    }
}
```

수정된 코드
```swift
struct ScoreView: View {
    @State var scale: Double = 1.0
    
    var body: some View {
        VStack(alignment: .leading) {
            { ... }   
        }
        .scaleEffect(scale)
        .animation(.easeIn(duration: 1).delay(0.2), value: fromPercent)
        .padding(20)
        .onAppear() {
            updateData()
        }
    }
    
    private func updateData() {
        // 승자일 때는 스케일을 무조건 1.2로 변경
        withAnimation {
            if gameResult == .win { scale = 1.2 }
            fromPercent = percent
        }
    }
}

```

<br>

## To Reviewers 🙏🏻

- [ ] 광고가 나올 때 대중픽 뷰에서 애니메이션 잘 적용되는지 봐 주세요
- [ ] 광고가 안 나올 때 대중픽 뷰에서 애니메이션 잘 적용되는지 봐 주세요
광고를 없앨 때 RecommandOrNotView.swift 에서 interstitialAd.show()를 주석처리하고 해주세요
스크린샷은 다음과 같음
<img src="https://github.com/Dream-Catch/Balance-Catch-iOS/assets/68800789/fe672213-9bb8-4306-bebd-6e466f19510a" width=60%>

<br>

## Linked Issue 🔗

- [x] #64 
