### PR TITLE
[#51]Enhancement: 서버에 요청 중 네트워크 연결 끊겼을 때 처리

### DIFF
--- a/Balance-Catch-iOS/Balance-Catch-iOS.xcodeproj/project.pbxproj
+++ b/Balance-Catch-iOS/Balance-Catch-iOS.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		56E2E4A929C055730023095C /* BeforePlayRuleDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E2E4A829C055730023095C /* BeforePlayRuleDescriptionView.swift */; };
 		56E2E4AB29C056BE0023095C /* PlayerNumberInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E2E4AA29C056BE0023095C /* PlayerNumberInputView.swift */; };
 		56EC27AA29DFEF4B00951070 /* ThemeButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EC27A929DFEF4B00951070 /* ThemeButtonStyle.swift */; };
+		56F4BEDF2A4FE8CB000A43E3 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F4BEDE2A4FE8CB000A43E3 /* View+.swift */; };
 		7167E719D33F7BC65621D457 /* Pods_Balance_Catch_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4852A0F878891D4D2943655 /* Pods_Balance_Catch_iOS.framework */; };
 		9F484326C205631CC8C89828 /* libPods-Balance-Catch-iOSUITests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9BD5EC6E488F01D3C72F9567 /* libPods-Balance-Catch-iOSUITests.a */; };
 /* End PBXBuildFile section */
@@ -155,6 +156,7 @@
 		56E2E4A829C055730023095C /* BeforePlayRuleDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeforePlayRuleDescriptionView.swift; sourceTree = "<group>"; };
 		56E2E4AA29C056BE0023095C /* PlayerNumberInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerNumberInputView.swift; sourceTree = "<group>"; };
 		56EC27A929DFEF4B00951070 /* ThemeButtonStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeButtonStyle.swift; sourceTree = "<group>"; };
+		56F4BEDE2A4FE8CB000A43E3 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		70A0185671401B81B9D8F5B9 /* Pods-Balance-Catch-iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Balance-Catch-iOSTests.release.xcconfig"; path = "Target Support Files/Pods-Balance-Catch-iOSTests/Pods-Balance-Catch-iOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		7ED71144ADCF04DBD9D33D89 /* Pods-Balance-Catch-iOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Balance-Catch-iOSTests.debug.xcconfig"; path = "Target Support Files/Pods-Balance-Catch-iOSTests/Pods-Balance-Catch-iOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		8AEAEC31989D3B8D6B601E2B /* Pods-Balance-Catch-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Balance-Catch-iOS.debug.xcconfig"; path = "Target Support Files/Pods-Balance-Catch-iOS/Pods-Balance-Catch-iOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -420,6 +422,7 @@
 				56E2E4A229C03C900023095C /* String+.swift */,
 				56CE463B2A04CC2400E95EF5 /* CancelBag.swift */,
 				562189362A39A48800E7C6FE /* UIApplication+.swift */,
+				56F4BEDE2A4FE8CB000A43E3 /* View+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -695,6 +698,7 @@
 				562189372A39A48800E7C6FE /* UIApplication+.swift in Sources */,
 				5640B0FC2A0378990041AB5A /* NetworkManager.swift in Sources */,
 				5675DD942A2201B30094E2D1 /* QuestionDataViewModel.swift in Sources */,
+				56F4BEDF2A4FE8CB000A43E3 /* View+.swift in Sources */,
 				3950657929CC93AF00A9C925 /* SelectTypeView.swift in Sources */,
 				56C0A19529FA141F000406CE /* BalanceCatchBackButton.swift in Sources */,
 				56E2E49F29C03B050023095C /* CGFloat+.swift in Sources */,

--- a/Balance-Catch-iOS/Balance-Catch-iOS/Extension/View+.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/Extension/View+.swift
@@ -8,16 +8,17 @@
 import SwiftUI
 
 extension View {
-    func networkAlert(showAlert: Binding<Bool>, function: @escaping () -> Void) -> some View {
+    
+    func networkAlert(showAlert: Binding<Bool>, completion: @escaping () -> Void) -> some View {
         self.alert(isPresented: showAlert) {
             Alert(title: Text("네트워크 연결이 끊겼습니다."),
                   primaryButton: .default(Text("설정"),
                                           action: {
                 openSettings()
-                function()
+                completion()
             }),
                   secondaryButton: .default(Text("재시도"), action: {
-                function()
+                completion()
             }))
         }
     }

--- a/Balance-Catch-iOS/Balance-Catch-iOS/Extension/View+.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/Extension/View+.swift
@@ -1,0 +1,32 @@
+//
+//  View+.swift
+//  Balance-Catch-iOS
+//
+//  Created by SeungMin on 2023/07/01.
+//
+
+import SwiftUI
+
+extension View {
+    func networkAlert(showAlert: Binding<Bool>, function: @escaping () -> Void) -> some View {
+        self.alert(isPresented: showAlert) {
+            Alert(title: Text("네트워크 연결이 끊겼습니다."),
+                  primaryButton: .default(Text("설정"),
+                                          action: {
+                openSettings()
+                function()
+            }),
+                  secondaryButton: .default(Text("재시도"), action: {
+                function()
+            }))
+        }
+    }
+    
+    private func openSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            if UIApplication.shared.canOpenURL(url) {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            }
+        }
+    }
+}

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/RecommandOrNotView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/RecommandOrNotView.swift
@@ -32,7 +32,7 @@ struct RecommandOrNotView: View {
                             questionDataViewModel
                                 .selectedQuestionData?
                                 .good += 1
-                            questionDataViewModel.putQuestionLike()
+                            questionDataViewModel.putQuestionData()
                             interstitialAd.show()
                         }))
                     
@@ -45,7 +45,7 @@ struct RecommandOrNotView: View {
                             questionDataViewModel
                                 .selectedQuestionData?
                                 .bad += 1
-                            questionDataViewModel.putQuestionLike()
+                            questionDataViewModel.putQuestionData()
                             interstitialAd.show()
                         }))
                     }
@@ -57,6 +57,7 @@ struct RecommandOrNotView: View {
                                value: Route.publicPickView)
                 .buttonStyle(RoundedBlueButton())
                 .simultaneousGesture(TapGesture().onEnded({
+                    questionDataViewModel.putQuestionData()
                     interstitialAd.show()
                 }))
             }
@@ -68,8 +69,9 @@ struct RecommandOrNotView: View {
         .onAppear() {
             updateQuestionScore()
         }
-        .balanceCatchBackButton {
-            dismiss()
+        .networkAlert(showAlert: $questionDataViewModel.showAlert) {
+            questionDataViewModel.putQuestionData()
+            interstitialAd.show()
         }
     }
     

--- a/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectTypeView.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/View/SelectTypeView.swift
@@ -69,6 +69,9 @@ struct SelectTypeView: View {
             if questionDataViewModel.isLoading { LoadingView() }
             else { EmptyView() }
         }
+        .networkAlert(showAlert: $questionDataViewModel.showAlert) {
+            fetchData()
+        }
     } //body
     
     private func fetchData() {

--- a/Balance-Catch-iOS/Balance-Catch-iOS/ViewModel/QuestionDataViewModel.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/ViewModel/QuestionDataViewModel.swift
@@ -41,7 +41,7 @@ final class QuestionDataViewModel: ObservableObject {
             .cancel(with: cancelBag)
     }
     
-    func putQuestionLike() {
+    func putQuestionData() {
         guard let selectedQuestionData = selectedQuestionData else { return }
         self.isLoading = true
         

--- a/Balance-Catch-iOS/Balance-Catch-iOS/ViewModel/QuestionDataViewModel.swift
+++ b/Balance-Catch-iOS/Balance-Catch-iOS/ViewModel/QuestionDataViewModel.swift
@@ -11,36 +11,40 @@ import Combine
 final class QuestionDataViewModel: ObservableObject {
     
     @Published var isLoading = false
+    @Published var showAlert = false
     var questionDataList = CurrentValueSubject<[QuestionDataModel], Never>([])
     var selectedQuestionData: QuestionDataModel? = nil
     var cancelBag = CancelBag()
     
     func getQuestionMetaData() {
-        isLoading = true
+        self.isLoading = true
+        
         NetworkManager.shared.getQuestionMetaData()
             .receive(on: DispatchQueue.main)
             .sink { result in
+                self.isLoading = false
+                
                 switch result {
                 case .finished:
                     print("데이터 응답 성공!")
+                    self.showAlert = false
                 case .failure(let error):
                     print("error - \(error.localizedDescription)")
-                    self.isLoading = false
+                    self.showAlert = true
                 }
             } receiveValue: { data in
                 let data = data.compactMap { questionDataResponseModel in
                     QuestionDataModel(response: questionDataResponseModel)
                 }
                 self.questionDataList.send(data)
-                self.isLoading = false
             }
             .cancel(with: cancelBag)
     }
     
     func putQuestionLike() {
         guard let selectedQuestionData = selectedQuestionData else { return }
+        self.isLoading = true
         
-        isLoading = true
         NetworkManager.shared.putQuestionLike(id: selectedQuestionData.id,
                                               good: selectedQuestionData.good,
                                               bad: selectedQuestionData.bad,
@@ -48,16 +52,17 @@ final class QuestionDataViewModel: ObservableObject {
                                               secondQuestionScore: selectedQuestionData.secondQuestionScore)
         .receive(on: DispatchQueue.main)
         .sink { result in
+            self.isLoading = false
+            
             switch result {
             case .finished:
                 print("수정 성공!")
+                self.showAlert = false
             case .failure(let error):
                 print("error - \(error)")
-                self.isLoading = false
+                self.showAlert = true
             }
-        } receiveValue: { data in
-            self.isLoading = false
-        }
-        .cancel(with: cancelBag)
+        } receiveValue: { _ in }
+            .cancel(with: cancelBag)
     }
 }


### PR DESCRIPTION
## Motivation ⍰

- 요청 중에 네트워크가 끊기면 alert을 띄움
- 경고창의 두 개의 버튼이 있고, 왼쪽은 설정, 오른쪽은 재시도
- 설정을 클릭하면 설정 화면으로 이동하고, 재시도를 클릭하면 요청을 재시도함
- 시뮬레이터에서 테스트할 때는 네트워크 끊긴 상태에서 네트워크를 다시 연결할 때 오래 걸림

<br>

## Key Changes 🔑

- 알럿을 통해서 왼쪽 버튼은 설정, 오른쪽은 재시도로 구현

설정과 재시도 버튼 두 버튼을 만들고 왼쪽 버튼은 설정, 오른쪽 버튼은 재시도

<img src="https://github.com/Dream-Catch/Balance-Catch-iOS/assets/68800789/87fec790-017e-43e0-b0bc-a32f8c3dfc31" width=25%> <img src="https://github.com/Dream-Catch/Balance-Catch-iOS/assets/68800789/1117b8fe-82c4-4327-bb33-f46c7eb0da3a" width=25%>


SwiftUI에서는 View의 함수로 alert()을 사용해서 경고창을 띄우는데 네트워크 연결 끊김 경고문은 모든 뷰에서 똑같이 적용할 수 있기 때문에 View를 확장해서 구현

코드는 다음과 같음

```swift
//
//  View+.swift
//  Balance-Catch-iOS
//
//  Created by SeungMin on 2023/07/01.
//

import SwiftUI

extension View {
    func networkAlert(showAlert: Binding<Bool>, function: @escaping () -> Void) -> some View {
        self.alert(isPresented: showAlert) {
            Alert(title: Text("네트워크 연결이 끊겼습니다."),
                  primaryButton: .default(Text("설정"),
                                          action: {
                openSettings()
                function()
            }),
                  secondaryButton: .default(Text("재시도"), action: {
                function()
            }))
        }
    }
    
    private func openSettings() {
        if let url = URL(string: UIApplication.openSettingsURLString) {
            if UIApplication.shared.canOpenURL(url) {
                UIApplication.shared.open(url, options: [:], completionHandler: nil)
            }
        }
    }
}
```

기본적으로 알럿의 버튼을 클릭하면 dismiss가 됨. 그래서 연결이 안 된 상태에서 경고문을 다시 띄우기 위해서 설정창을 띄운 뒤에도 function()을 수행

```swift
//  QuestionDataViewModel.swift
final class QuestionDataViewModel: ObservableObject {
    
    @Published var isLoading = false
    @Published var showAlert = false
    var questionDataList = CurrentValueSubject<[QuestionDataModel], Never>([])
    var selectedQuestionData: QuestionDataModel? = nil
    var cancelBag = CancelBag()
    
    func getQuestionMetaData() {
        self.isLoading = true
        
        NetworkManager.shared.getQuestionMetaData()
            .receive(on: DispatchQueue.main)
            .sink { result in
                self.isLoading = false
                
                switch result {
                case .finished:
                    print("데이터 응답 성공!")
                    self.showAlert = false
                case .failure(let error):
                    print("error - \(error.localizedDescription)")
                    self.showAlert = true
                }
            } receiveValue: { data in
                let data = data.compactMap { questionDataResponseModel in
                    QuestionDataModel(response: questionDataResponseModel)
                }
                self.questionDataList.send(data)
            }
            .cancel(with: cancelBag)
    }
}
```

viewModel에서 showAlert published 변수를 생성해서 요청이 성공하면 false, 에러가 나면 true로 설정

```swift
//  SelectTypeView.swift
import SwiftUI

struct SelectTypeView: View {
    var body: some View {
        ZStack {
            { ... }
        }
        .networkAlert(showAlert: $questionDataViewModel.showAlert) {
            fetchData()
        }
    } //body
    
    private func fetchData() {
        questionDataViewModel.getQuestionMetaData()
    }
}
```

questionDataViewModel.showAlert binding 변수가 변경될 때마다 서버에 요청을 보내고 에러를 받으면 alert을 다시 띄움

<br>

## To Reviewers 🙏🏻

- [x] 네트워크 연결 끊은 상태에서 설정 버튼 클릭 했을 때 설정이 잘 나오는 지 봐주세요
- [x] 네트워크를 재연결 후, 재시도 버튼 클릭 했을 때 응답을 잘 받는지 확인해주세요

<br>

## Linked Issue 🔗

- [x] #51 
